### PR TITLE
Add missing fallback (*) to ner-es mapping

### DIFF
--- a/de.tudarmstadt.ukp.dkpro.core.stanfordnlp-gpl/src/main/resources/de/tudarmstadt/ukp/dkpro/core/stanfordnlp/lib/ner-es-ancora.distsim.s512.crf.map
+++ b/de.tudarmstadt.ukp.dkpro.core.stanfordnlp-gpl/src/main/resources/de/tudarmstadt/ukp/dkpro/core/stanfordnlp/lib/ner-es-ancora.distsim.s512.crf.map
@@ -3,3 +3,4 @@ LUG=de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location
 ORG=de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization
 #OTROS
 PERS=de.tudarmstadt.ukp.dkpro.core.api.ner.type.Person
+*=de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity


### PR DESCRIPTION
The missing fallback causes this exception when using Spanish NER on 1.8.0-SNAPSHOT: 

java.lang.IllegalStateException: No fallback (*) mapping defined!
	at de.tudarmstadt.ukp.dkpro.core.api.resources.MappingProvider.getTagTypeName(MappingProvider.java:106)
	at de.tudarmstadt.ukp.dkpro.core.api.resources.MappingProvider.getTagType(MappingProvider.java:72)