### PR TITLE
Added StanfordPosTagger option that skips sentences with more tokens …

### DIFF
--- a/de.tudarmstadt.ukp.dkpro.core.stanfordnlp-gpl/src/main/java/de/tudarmstadt/ukp/dkpro/core/stanfordnlp/StanfordPosTagger.java
+++ b/de.tudarmstadt.ukp.dkpro.core.stanfordnlp-gpl/src/main/java/de/tudarmstadt/ukp/dkpro/core/stanfordnlp/StanfordPosTagger.java
@@ -139,6 +139,15 @@ public class StanfordPosTagger
     @ConfigurationParameter(name = PARAM_QUOTE_END, mandatory = false)
     private List<String> quoteEnd;
 	
+	/**
+     * Sentences with more tokens than the specified max amount will be ignored if this parameter
+     * is set to a value larger than zero. The default value zero will allow all sentences to be
+     * POS tagged.
+	 */
+	public static final String PARAM_MAX_SENTENCE_TOKENS = "maxSentenceTokens";
+	@ConfigurationParameter(name = PARAM_MAX_SENTENCE_TOKENS, mandatory = false)
+	private int maxSentenceTokens = 0;
+
 	private CasConfigurableProviderBase<MaxentTagger> modelProvider;
 	private MappingProvider posMappingProvider;
 
@@ -210,6 +219,8 @@ public class StanfordPosTagger
 
 		for (Sentence sentence : select(aJCas, Sentence.class)) {
 			List<Token> tokens = selectCovered(aJCas, Token.class, sentence);
+			
+			if(maxSentenceTokens > 0 && tokens.size() > maxSentenceTokens) continue;
 
 			List<HasWord> words = new ArrayList<HasWord>(tokens.size());
 			for (Token t : tokens) {


### PR DESCRIPTION
The quadratic increase in computational complexity of the Stanford tagger becomes a processing bottleneck when many very long sentences are encountered during processing of a larger document corpus. We would like to add an option to skip sentences beyond a maximum number of tokens in the DKPro StandfordPosTagger analysis engine. Alternatively only the maximum number of tokens could be run through the POS tagger instead of skipping the whole sentence but I haven't tested the impact in terms of performance and quality of doing this on a larger scale so I rather avoid this for now.

This patch should be very trivial but let me know if I need to make any changes.