### PR TITLE
Fix RfTagger morph mapping

### DIFF
--- a/dkpro-core-api-lexmorph-asl/src/main/resources/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/tagset/de-tiger-rftagger-morph.map
+++ b/dkpro-core-api-lexmorph-asl/src/main/resources/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/tagset/de-tiger-rftagger-morph.map
@@ -1,6 +1,7 @@
 # TIGER (RfTagger)
 #
-# Source: SOME URL
+# Source: http://www.cis.uni-muenchen.de/~schmid/tools/RFTagger/data/RFTagger.tar.gz
+# See: /doc/german-tagset
 #
 
 #
@@ -74,7 +75,7 @@ definiteness.Def=\.Def\.
 # Tagset: http://universaldependencies.github.io/docs/u/feat/Degree.html (2014-11-18)
 #
 degree.Pos=\.Pos\.
-degree.Cmp=\.Dat\.
+degree.Cmp=\.Comp\.
 degree.Sup=\.Sup\.
 # degree.Abs=
 
@@ -86,18 +87,18 @@ degree.Sup=\.Sup\.
 gender.Masc=\.Masc
 gender.Fem=\.Fem
 gender.Neut=\.Neut
-gender.Com=\.Ind
+# gender.Com=
 
 #
 # Feature: mood
 #
 # Tagset: http://universaldependencies.github.io/docs/u/feat/Mood.html (2014-11-18)
 #
-# mood.Ind=
+mood.Ind=VFIN.*\.Ind
 # mood.Imp=
 # mood.Cnd=
 # mood.Pot=
-# mood.Sub=
+mood.Sub=VFIN.*\.Subj
 # mood.Jus=
 # mood.Qot=
 # mood.Opt=


### PR DESCRIPTION
Hi,

This pull request fixes several issues in the morph mapping file for the `RfTagger`. See [1] for more information. It also adds the original mapping reference for documentation purpose and enables `Mood` for `VFIN`. I've also updated a wrong `Degree` label. 

Best Uli

[1] https://groups.google.com/forum/#!topic/dkpro-core-user/wRk20eI6sPc 