### PR TITLE
fix(pom): Snowball POM of 1.8 branch was referencing 1.9.0

### DIFF
--- a/dkpro-core-snowball-asl/pom.xml
+++ b/dkpro-core-snowball-asl/pom.xml
@@ -84,7 +84,7 @@
             <dependency>
                 <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
                 <artifactId>de.tudarmstadt.ukp.dkpro.core.opennlp-asl</artifactId>
-                <version>1.9.0-SNAPSHOT</version>
+                <version>1.8.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Fixes a POM dependency error, which caused maven build problems. Please just reject if this patch is not appropriate or already done elsewhere.