### PR TITLE
Backmapper breaks if feature structures are not subtypes of Annotation

### DIFF
--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
@@ -161,19 +161,21 @@ extends JCasAnnotator_ImplBase
 	    
         while (it.hasNext()) {
             FeatureStructure fs = targetView.getLowLevelCas().ll_getFSForRef(it.next());
+            if(fs instanceof Annotation) {
 
-            // Now we update the offsets
-            Annotation a = (Annotation) fs;
+                // Now we update the offsets
+                Annotation a = (Annotation) fs;
 //            System.out.printf("Orig   %s %3d %3d : %s%n", a.getType().getShortName(),
 //                    a.getBegin(), a.getEnd(),
 //                    sourceView.getDocumentText().substring(a.getBegin(), a.getEnd()));
 //            System.out.printf("Before %s %3d %3d : %s%n", a.getType().getShortName(),
 //                    a.getBegin(), a.getEnd(), a.getCoveredText());
-            Interval resolved = as.resolve(new ImmutableInterval(a.getBegin(), a.getEnd()));
-            a.setBegin(resolved.getStart());
-            a.setEnd(resolved.getEnd());
+                Interval resolved = as.resolve(new ImmutableInterval(a.getBegin(), a.getEnd()));
+                a.setBegin(resolved.getStart());
+                a.setEnd(resolved.getEnd());
 //            System.out.printf("After  %s %3d %3d : %s%n", a.getType().getShortName(),
 //                    a.getBegin(), a.getEnd(), a.getCoveredText());
+            }
         }
 	}
 }


### PR DESCRIPTION
The Backmapper breaks if feature structures are not subtypes of Annotation like the CoreferenceChain type produced by the DKPro Stanford coreference analyser.

Caused by: java.lang.ClassCastException: de.tudarmstadt.ukp.dkpro.core.api.coref.type.CoreferenceChain cannot be cast to org.apache.uima.jcas.tcas.Annotation
	at de.tudarmstadt.ukp.dkpro.core.castransformation.Backmapper.updateOffsets(Backmapper.java:166)
	at de.tudarmstadt.ukp.dkpro.core.castransformation.Backmapper.process(Backmapper.java:120)
	at org.apache.uima.analysis_component.JCasAnnotator_ImplBase.process(JCasAnnotator_ImplBase.java:48)
	at org.apache.uima.analysis_engine.impl.PrimitiveAnalysisEngine_impl.callAnalysisComponentProcess(PrimitiveAnalysisEngine_impl.java:385)
	... 16 more

This fix just ignores those feature structures when setting the begin and end properties of annotations since they are still properly copied to the target view by the CAS copier.
