### PR TITLE
Fix To TreeTagger Build Script and UDIPipeTest

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -30,6 +30,7 @@ Lisa Beinborn <lisa.beinborn@gmail.com>
 Marcel Ackermann <dreamflasher@dreamflasher.de>
 Martin Riedl <riedl.ma@gmail.com>
 Mateusz Parzonka
+Milen Kouylekov <milen.kouylekov@usit.uio.no>
 Nicolai Erbs <nico.erbs@gmail.com>
 Niklas Jakob
 Nils Reimers

--- a/dkpro-core-treetagger-asl/src/scripts/build.xml
+++ b/dkpro-core-treetagger-asl/src/scripts/build.xml
@@ -36,7 +36,7 @@
 		<antcall target="separate-jars"/>
 	</target>
 
-	<target name="separate-jars" depends="check-license,install-executables,bg,de,en,es,et,fi,fr,gl,it,la,mn,nl,pl,pt,sk,sl,sw,zh,jar-notice"/>
+	<target name="separate-jars" depends="check-license,install-executables,bg,de,en,es,et,fi,fr,gl,it,la,mn,nl,pl,pt,ru,sk,sl,sw,zh,jar-notice"/>
 
 	<target name="bg">
 		<antcall target="bg-tagger-le"/>
@@ -833,12 +833,13 @@
 		  -->
 		<!-- FILE: tree-tagger-MacOSX-3.2-intel.tar.gz - - - - - - - - - - - - - - - - - - - - - - -
 		  - 2010-11-19 | 2012-04-25 | 076c8002337b89a9a8581aae81d5d481
-		  - 2012-04-25 | now        | a47bac91b5f373c5ba8703faa5ec7dd7 : buffer flush after 10 lines with -prob 
+		  - 2012-04-25 | 2016-11-24 | a47bac91b5f373c5ba8703faa5ec7dd7 : buffer flush after 10 lines with -prob 
+		  - 2016-11-24 | now        | 0b6d122c1b66ecc557cb856f44041368 : The file name is changed from tree-tagger-MacOSX-3.2-intel.tar.gz to tree-tagger-MacOSX-3.2.tar.gz
 		  -->
-		<install-executable-file-tar url="http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-MacOSX-3.2-intel.tar.gz"
-			platform="osx-x86_64" file="tree-tagger" md5="a47bac91b5f373c5ba8703faa5ec7dd7"/>
-		<install-executable-file-tar url="http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-MacOSX-3.2-intel.tar.gz"
-			platform="osx-x86_32" file="tree-tagger" md5="a47bac91b5f373c5ba8703faa5ec7dd7"/>
+		<install-executable-file-tar url="http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-MacOSX-3.2.tar.gz"
+			platform="osx-x86_64" file="tree-tagger" md5="0b6d122c1b66ecc557cb856f44041368"/>
+		<install-executable-file-tar url="http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-MacOSX-3.2.tar.gz"
+			platform="osx-x86_32" file="tree-tagger" md5="0b6d122c1b66ecc557cb856f44041368"/>
 		
 		<!-- FILE: tree-tagger-MacOSX-3.2.tar.gz - - - - - - - - - - - - - - - - - - - - - - - - - -
 		  - 2010-11-19 | now        | 63560dcb3a5932bc5ae0e9aab8f48e42

--- a/dkpro-core-udpipe-asl/src/scripts/build.xml
+++ b/dkpro-core-udpipe-asl/src/scripts/build.xml
@@ -23,7 +23,7 @@
 	</import>
 	
 	<target name="local-maven">
-		<property name="install-artifact-enable" value="true"/>
+		<property name="install-artifact-mode" value="local"/>
 		<antcall target="separate-jars"/>
 	</target>
 	
@@ -202,7 +202,7 @@
             version="${version.bin}"/>
 
         <install-artifact 
-            file="target/dkpro-core-udpipe-bin-bin-${version.bin}.jar"
+            file="target/dkpro-core-udpipe-bin-${version.bin}.jar"
             groupId="org.dkpro.core"
             artifactId="dkpro-core-udpipe-bin" 
             version="${version.bin}"/>

--- a/dkpro-core-udpipe-asl/src/test/java/org/dkpro/core/udpipe/UDPosTaggerTest.java
+++ b/dkpro-core-udpipe-asl/src/test/java/org/dkpro/core/udpipe/UDPosTaggerTest.java
@@ -40,7 +40,8 @@ public class UDPosTaggerTest
         // N.B. This test is incomplete as I am not sure how exactly the POS should be.
         runTest("no", null, "Magnus Carlsen trengte bare de fire partiene med lynsjakk for å slå utfordreren Sergej Karjakin.",
                 new String[] { "PROPN", "PROPN", "VERB", "ADV", "DET", "NUM", "NOUN", "ADP", "NOUN", "ADP", "PART", "VERB", "NOUN", "PROPN", "PROPN" },
-                new String[] { "POS", "POS", "POS", "POS", "POS", "POS", "POS", "POS", "POS", "POS", "POS", "POS", "POS", "POS", "POS" });
+                new String[] { "PROPN", "PROPN", "VERB", "ADV", "DET", "NUM", "NOUN", "ADP", "NOUN", "ADP", "PART", "VERB", "NOUN", "PROPN", "PROPN"
+ });
     }
     
     @Test


### PR DESCRIPTION
Hi  Richard,

I have fixed the TreeTagger build scipt to the new URL. Also added the ru model to the separate-jars target. 

I also fixed the UDIPipeTest for Norwegian. Before it was working against my broken model. Now that you have fixed it I have changed the values to correct ones. 
Cheers Milen