### PR TITLE
Added possibility to merge typesystems in BinaryCasReader

### DIFF
--- a/dkpro-core-io-bincas-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/bincas/BinaryCasReader.java
+++ b/dkpro-core-io-bincas-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/bincas/BinaryCasReader.java
@@ -57,231 +57,234 @@ import de.tudarmstadt.ukp.dkpro.core.api.resources.CompressionUtils;
  * UIMA Binary CAS formats reader.
  */
 @MimeTypeCapability({ MimeTypes.APPLICATION_X_UIMA_BINARY })
-public class BinaryCasReader
-    extends ResourceCollectionReaderBase
-{
-    private static final byte[] DKPRO_HEADER = new byte[] { 'D', 'K', 'P', 'r', 'o', '1' };
-    
-    /**
-     * The location from which to obtain the type system when the CAS is stored in form 0.
-     */
-    public static final String PARAM_TYPE_SYSTEM_LOCATION = "typeSystemLocation";
-    @ConfigurationParameter(name=PARAM_TYPE_SYSTEM_LOCATION, mandatory=false)
-    private String typeSystemLocation;
-    
-    private CASMgrSerializer casMgrSerializer;
-    private TypeSystemImpl typeSystem;
-        
-    @Override
-    public void getNext(CAS aCAS)
-        throws IOException, CollectionException
-    {
-        // Get type system description of the current CAS
-        TypeSystemDescription tsd1 = 
-        		TypeSystemUtil.typeSystem2TypeSystemDescription(aCAS.getTypeSystem());
-    	
-        Resource res = nextFile();
-        
-        // Get type system from input file
-        TypeSystemDescription tsd2;
-        TypeSystemImpl xts = null;
-        byte[] header = new byte[DKPRO_HEADER.length];
-        try (InputStream is = CompressionUtils.getInputStream(res.getLocation(),
-                res.getInputStream())) {
-            BufferedInputStream bis = new BufferedInputStream(is);
-            
-            getLogger().debug("Reading CAS from [" + res.getLocation() + "]");
+public class BinaryCasReader extends ResourceCollectionReaderBase {
+	private static final byte[] DKPRO_HEADER = new byte[] { 'D', 'K', 'P', 'r', 'o', '1' };
 
-            // Prepare for format detection
-            bis.mark(32);
-            DataInputStream dis = new DataInputStream(bis);
-            dis.read(header);
-            
-            // Use externalized type system
-            if (typeSystemLocation != null) {
-                // Otherwise try reading an externalized type system
-                xts = readTypeSystem();
-                
-                // If we encounter a Java-serialized file with an external TSI, then we
-                // reinitalize the CAS with the external TSI prior to loading the data
-                if (header[0] == (byte) 0xAC && header[1] == (byte) 0xED) {
-                    CASMgrSerializer casMgr = readCasManager();
-                    ((CASImpl)aCAS).setupCasFromCasMgrSerializer(casMgr);
-                }
-            }
-            
-            xts = readDKProHeader(bis, header, xts);
-            
-            if (xts != null) {
-            	tsd2 = TypeSystemUtil.typeSystem2TypeSystemDescription(xts);
-            }
-            else {
-                CasIOUtils.load(bis, null, aCAS, CasLoadMode.DEFAULT);
-                tsd2 = TypeSystemUtil.typeSystem2TypeSystemDescription(aCAS.getTypeSystem());
-            }
-        }
-        
-        try {
-	        // Merge the two typesystems
-	        TypeSystemDescription mergedTypeSystem = 
-	        		CasCreationUtils.mergeTypeSystems(Arrays.asList(tsd1, tsd2));
-	
-	        // Create a new CAS based on the merged type system
-	        JCas mergedTypeSystemCas = 
-	        		CasCreationUtils.createCas(mergedTypeSystem, 
-	        								   (TypePriorities) null, 
-	        								   (FsIndexDescription[]) null)
-	        						.getJCas();
-	
-	        // Create a holder for the CAS metadata
-	        CASMgrSerializer casMgrSerializer = 
-	        		Serialization.serializeCASMgr((mergedTypeSystemCas).getCasImpl());
-	        
-	        // Reinitialize CAS with new type system
-	       ((CASImpl)aCAS).setupCasFromCasMgrSerializer(casMgrSerializer);
-	        
-	        // Read file again, this time into a CAS which has been prepared with the merged TS
-	        try (InputStream is = CompressionUtils.getInputStream(res.getLocation(),
-	                res.getInputStream())) {
-	        	
-	        	BufferedInputStream bis = new BufferedInputStream(is);
-	            bis.mark(32);
-	        	DataInputStream dis = new DataInputStream(bis);
-	            dis.read(header);
-	        	xts = readDKProHeader(bis, header, xts);
-	        	
-	            SerialFormat format;
-		        if (xts != null) {
-		        	format = CasIOUtils.load(bis, aCAS, xts);
-	            }
-	            else {
-	            	format = CasIOUtils.load(bis, aCAS);
-	            }
-	            getLogger().debug("Found format " + format);
-	        } catch (IOException e) {
-	            throw new CollectionException(e);
+	/**
+	 * The location from which to obtain the type system when the CAS is stored
+	 * in form 0.
+	 */
+	public static final String PARAM_TYPE_SYSTEM_LOCATION = "typeSystemLocation";
+	@ConfigurationParameter(name = PARAM_TYPE_SYSTEM_LOCATION, mandatory = false)
+	private String typeSystemLocation;
+
+	public static final String PARAM_MERGE_TYPE_SYSTEM = "mergeTypeSystem";
+	@ConfigurationParameter(name = PARAM_MERGE_TYPE_SYSTEM, mandatory = true, defaultValue = "false")
+	private boolean mergeTypeSystem;
+
+	private CASMgrSerializer casMgrSerializer;
+	private TypeSystemImpl typeSystem;
+
+	@Override
+	public void getNext(CAS aCAS) throws IOException, CollectionException {
+		Resource res = nextFile();
+		TypeSystemImpl xts = null;
+		byte[] header = new byte[DKPRO_HEADER.length];
+
+		if (this.mergeTypeSystem) {
+			// Get type system from input file
+			TypeSystemDescription tsd2;
+
+			try (InputStream is = CompressionUtils.getInputStream(res.getLocation(),
+					res.getInputStream())) {
+				BufferedInputStream bis = new BufferedInputStream(is);
+
+				getLogger().debug("Reading CAS from [" + res.getLocation() + "]");
+
+				// Prepare for format detection
+				bis.mark(32);
+				DataInputStream dis = new DataInputStream(bis);
+				dis.read(header);
+
+				// Use externalized type system
+				if (typeSystemLocation != null) {
+					xts = readTypeSystem(header, aCAS);
+				}
+
+				xts = readDKProHeader(bis, header, xts);
+
+				if (xts != null) {
+					tsd2 = TypeSystemUtil.typeSystem2TypeSystemDescription(xts);
+				} else {
+					CasIOUtils.load(bis, null, aCAS, CasLoadMode.REINIT);
+					tsd2 = TypeSystemUtil.typeSystem2TypeSystemDescription(aCAS.getTypeSystem());
+				}
 			}
-        }
-        catch (CASException | ResourceInitializationException e) {
-            throw new CollectionException(e);
-        }
-        
-        // Initialize the JCas sub-system which is the most often used API in DKPro Core components
-        try {
-            aCAS.getJCas();
-        }
-        catch (CASException e) {
-            throw new CollectionException(e);
-        }
-    }
-    
-    private TypeSystemImpl readDKProHeader (BufferedInputStream bis, byte[] header, TypeSystemImpl ts) {
-    	// Check if this is original UIMA CAS format or DKPro Core format
-        if (Arrays.equals(header, DKPRO_HEADER)) {
-            // If it is DKPro Core format, read the type system
-            getLogger().debug("Found DKPro-Core-style embedded type system");
-            ObjectInputStream ois;
+
+			try {
+				// Merge the two typesystems
+				TypeSystemDescription mergedTypeSystem = CasCreationUtils.mergeTypeSystems(Arrays
+						.asList(TypeSystemUtil.typeSystem2TypeSystemDescription(typeSystem), tsd2));
+
+				// Create a new CAS based on the merged type system
+				JCas mergedTypeSystemCas = CasCreationUtils.createCas(mergedTypeSystem,
+						(TypePriorities) null, (FsIndexDescription[]) null).getJCas();
+
+				// Create a holder for the CAS metadata
+				CASMgrSerializer casMgrSerializer = Serialization
+						.serializeCASMgr((mergedTypeSystemCas).getCasImpl());
+
+				// Reinitialize CAS with new type system
+				((CASImpl) aCAS).setupCasFromCasMgrSerializer(casMgrSerializer);
+
+			} catch (CASException | ResourceInitializationException e) {
+				throw new CollectionException(e);
+			}
+		}
+
+		// Read file again, this time into a CAS which has been prepared with
+		// the merged TS
+		try (InputStream is = CompressionUtils.getInputStream(res.getLocation(),
+				res.getInputStream())) {
+			BufferedInputStream bis = new BufferedInputStream(is);
+			bis.mark(32);
+			DataInputStream dis = new DataInputStream(bis);
+			dis.read(header);
+			
+			// Use externalized type system
+			if (typeSystemLocation != null) {
+				xts = readTypeSystem(header,aCAS);				
+			}
+			
+			xts = readDKProHeader(bis, header, xts);
+			
+			SerialFormat format;
+			if (xts != null) {
+				format = CasIOUtils.load(bis, aCAS, xts);
+			} else {
+ 				format = CasIOUtils.load(bis, aCAS);
+			}
+			getLogger().debug("Found format " + format);
+		} catch (IOException e) {
+			throw new CollectionException(e);
+		}
+
+		// Initialize the JCas sub-system which is the most often used API in
+		// DKPro Core components
+		try {
+			aCAS.getJCas();
+		} catch (CASException e) {
+			throw new CollectionException(e);
+		}
+	}
+
+	// Legacy DKPro file format support
+	private TypeSystemImpl readDKProHeader(BufferedInputStream bis, byte[] header,
+			TypeSystemImpl ts) {
+		// Check if this is original UIMA CAS format or DKPro Core format
+		if (Arrays.equals(header, DKPRO_HEADER)) {
+			// If it is DKPro Core format, read the type system
+			getLogger().debug("Found DKPro-Core-style embedded type system");
+			ObjectInputStream ois;
 			try {
 				ois = new ObjectInputStream(bis);
 				CASMgrSerializer casMgr = (CASMgrSerializer) ois.readObject();
 				if (ts == null) {
-	                ts = casMgr.getTypeSystem();
-	                ts.commit();
-	            }
+					ts = casMgr.getTypeSystem();
+					ts.commit();
+				}
 			} catch (IOException e) {
 				e.printStackTrace();
 			} catch (ClassNotFoundException e) {
 				e.printStackTrace();
 			}
-        }
-        else {
-            // No embedded TS, reset 
-            try {
+		} else {
+			// No embedded DKPro TS, reset
+			try {
 				bis.reset();
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
-        }
-        return ts;
-    }
-    
-    /**
-     * It is possible that the type system overlaps with the scan pattern for files, e.g. because
-     * the type system ends in {@code .ser} and the resources also end in {@code .ser}. If this is
-     * the case, we filter the type system file from the resource files during scanning.
-     */
-    @Override
-    protected Collection<Resource> scan(String aBase, Collection<String> aIncludes,
-            Collection<String> aExcludes)
-        throws IOException
-    {
-        Collection<Resource> resources = super.scan(aBase, aIncludes, aExcludes);
-        if (typeSystemLocation != null) {
-            org.springframework.core.io.Resource r = getTypeSystemResource();
-            resources.remove(new Resource(null, null, r.getURI(), null, null, r));
-        }
-        return resources;
-    }
-    
-    protected org.springframework.core.io.Resource getTypeSystemResource() throws MalformedURLException
-    {
-        org.springframework.core.io.Resource r;
-        // Is absolute?
-        if (typeSystemLocation.indexOf(':') != -1 || typeSystemLocation.startsWith("/")
-                || typeSystemLocation.startsWith(File.separator)) {
-            // If the type system location is absolute, resolve it absolute
-            r = getResolver().getResource(locationToUrl(typeSystemLocation));
-        }
-        else {
-            // If the type system is not absolute, resolve it relative to the base location
-            r = getResolver().getResource(getBase() + typeSystemLocation);
-        }
-        return r;
-    }
-    
-    private TypeSystemImpl readTypeSystem() throws IOException {
-        if (typeSystemLocation == null) {
-            return null;
-        }
-        
-        if (typeSystem == null) {
-            CASMgrSerializer casMgr = readCasManager();
-            typeSystem = casMgr.getTypeSystem();
-            typeSystem.commit();
-        }
-        
-        return typeSystem;
-    }
-    
-    
-    private CASMgrSerializer readCasManager() throws IOException
-    {
-        if (typeSystemLocation == null) {
-            return null;
-        }
-        
-        // If we already read the type system, return it - do not read it again.
-        if (casMgrSerializer != null) {
-            return casMgrSerializer;
-        }
-        
-        org.springframework.core.io.Resource r = getTypeSystemResource();
-        getLogger().debug("Reading type system from [" + r.getURI() + "]");
+		}
+		return ts;
+	}
 
-        ObjectInputStream is = null;
-        try {
-            is = new ObjectInputStream(CompressionUtils.getInputStream(typeSystemLocation, 
-                    r.getInputStream()));
-            casMgrSerializer = (CASMgrSerializer) is.readObject();
-        }
-        catch (ClassNotFoundException e) {
-            throw new IOException(e);
-        }
-        finally {
-            closeQuietly(is);
-        }
-        
-        
-        return casMgrSerializer;
-    }
+	@Override
+	public void typeSystemInit(TypeSystem aTypeSystem) throws ResourceInitializationException {
+		if (typeSystemLocation == null) {
+		typeSystem = (TypeSystemImpl) aTypeSystem;
+		}
+	}
+
+	/**
+	 * It is possible that the type system overlaps with the scan pattern for
+	 * files, e.g. because the type system ends in {@code .ser} and the
+	 * resources also end in {@code .ser}. If this is the case, we filter the
+	 * type system file from the resource files during scanning.
+	 */
+	@Override
+	protected Collection<Resource> scan(String aBase, Collection<String> aIncludes,
+			Collection<String> aExcludes) throws IOException {
+		Collection<Resource> resources = super.scan(aBase, aIncludes, aExcludes);
+		if (typeSystemLocation != null) {
+			org.springframework.core.io.Resource r = getTypeSystemResource();
+			resources.remove(new Resource(null, null, r.getURI(), null, null, r));
+		}
+		return resources;
+	}
+
+	protected org.springframework.core.io.Resource getTypeSystemResource()
+			throws MalformedURLException {
+		org.springframework.core.io.Resource r;
+		// Is absolute?
+		if (typeSystemLocation.indexOf(':') != -1 || typeSystemLocation.startsWith("/")
+				|| typeSystemLocation.startsWith(File.separator)) {
+			// If the type system location is absolute, resolve it absolute
+			r = getResolver().getResource(locationToUrl(typeSystemLocation));
+		} else {
+			// If the type system is not absolute, resolve it relative to the
+			// base location
+			r = getResolver().getResource(getBase() + typeSystemLocation);
+		}
+		return r;
+	}
+
+	private TypeSystemImpl readTypeSystem(byte[] header, CAS aCAS ) throws IOException {
+		if (typeSystemLocation == null) {
+			return null;
+		}
+
+		if (typeSystem == null) {
+			CASMgrSerializer casMgr = readCasManager();
+			typeSystem = casMgr.getTypeSystem();
+			typeSystem.commit();
+		}
+		
+		// If we encounter a Java-serialized file with an external
+		// TSI, then we reinitalize the CAS with the external TSI
+		// prior to loading the data
+		if (header[0] == (byte) 0xAC && header[1] == (byte) 0xED) {
+			CASMgrSerializer casMgr = readCasManager();
+			((CASImpl) aCAS).setupCasFromCasMgrSerializer(casMgr);
+		}
+
+		return typeSystem;
+	}
+
+	private CASMgrSerializer readCasManager() throws IOException {
+		if (typeSystemLocation == null) {
+			return null;
+		}
+
+		// If we already read the type system, return it - do not read it again.
+		if (casMgrSerializer != null) {
+			return casMgrSerializer;
+		}
+
+		org.springframework.core.io.Resource r = getTypeSystemResource();
+		getLogger().debug("Reading type system from [" + r.getURI() + "]");
+
+		ObjectInputStream is = null;
+		try {
+			is = new ObjectInputStream(
+					CompressionUtils.getInputStream(typeSystemLocation, r.getInputStream()));
+			casMgrSerializer = (CASMgrSerializer) is.readObject();
+		} catch (ClassNotFoundException e) {
+			throw new IOException(e);
+		} finally {
+			closeQuietly(is);
+		}
+
+		return casMgrSerializer;
+	}
 }

--- a/dkpro-core-io-bincas-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/bincas/BinaryCasReader.java
+++ b/dkpro-core-io-bincas-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/bincas/BinaryCasReader.java
@@ -109,12 +109,7 @@ public class BinaryCasReader
 				xts = readDKProHeader(bis, header, xts);
 	 		} else {
 	 			// No embedded DKPro TS, reset
-	 			try {
-	 				bis.reset();
-	 			} catch (IOException e) {
-	 				throw new IOException(e);
-	 			}
-	 			
+	 			bis.reset();
 	            // Try reading an externalized type system instead
 	            if (typeSystemLocation != null) {
 	            	xts = readTypeSystem();
@@ -166,13 +161,8 @@ public class BinaryCasReader
 				xts = readDKProHeader(bis, header, xts);
 	 		} else {
 	 			// No embedded DKPro TS, reset
-	 			try {
-	 				bis.reset();
-	 			} catch (IOException e) {
-	 				throw new IOException(e);
-	 			}
-	 			
-				// Try reading an externalized type system instead
+	 			bis.reset();
+	 			// Try reading an externalized type system instead
 				if (typeSystemLocation != null) {
 					xts = readTypeSystem();
 					initCasFromEmbeddedTS(header, aCAS);

--- a/dkpro-core-io-bincas-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/bincas/BinaryCasWriterReaderTest.java
+++ b/dkpro-core-io-bincas-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/bincas/BinaryCasWriterReaderTest.java
@@ -90,7 +90,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), SerialFormat.SERIALIZED.toString(), true);
-        read(testFolder.getPath(), NONE, true); // Type system is reinitialized from the persisted type system
+        read(testFolder.getPath(), NONE, true, false); // Type system is reinitialized from the persisted type system
+        read(testFolder.getPath(), NONE, true, true);
     }
 
     @Test
@@ -98,7 +99,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write("jar:file:" + testFolder.getPath() + "/archive.zip", "S", true);
-        read("jar:file:" + testFolder.getPath() + "/archive.zip", NONE, true); // Type system is reinitialized from the persisted type system
+        read("jar:file:" + testFolder.getPath() + "/archive.zip", NONE, true, false); // Type system is reinitialized from the persisted type system
+        read("jar:file:" + testFolder.getPath() + "/archive.zip", NONE, true, true);
     }
 
     @Test
@@ -106,7 +108,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), "S", false);
-        read(testFolder.getPath(), ALL, false);
+        read(testFolder.getPath(), ALL, false, false);
+        read(testFolder.getPath(), ALL, false, true);
     }
 
     @Test
@@ -114,7 +117,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), "S+", false);
-        read(testFolder.getPath(), NONE, false); // Type system is reinitialized from the persisted CAS
+        read(testFolder.getPath(), NONE, false, false); // Type system is reinitialized from the persisted CAS
+        read(testFolder.getPath(), NONE, false, true);
     }
 
     @Test
@@ -122,7 +126,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), SerialFormat.BINARY.toString(), false);
-        read(testFolder.getPath(), ALL, false);
+        read(testFolder.getPath(), ALL, false, false);
+        read(testFolder.getPath(), ALL, false, true);    
     }
 
     @Test
@@ -130,7 +135,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), "4", false);
-        read(testFolder.getPath(), ALL, false);
+        read(testFolder.getPath(), ALL, false, false);
+        read(testFolder.getPath(), ALL, false, true);
     }
     
     /**
@@ -142,7 +148,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), SerialFormat.COMPRESSED_FILTERED.toString(), true);
-        read(testFolder.getPath(), METADATA, true);
+        read(testFolder.getPath(), METADATA, true, false);
+        read(testFolder.getPath(), METADATA, true, true);
     }
 
     @Test
@@ -150,7 +157,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), "6", false);
-        read(testFolder.getPath(), ALL, false);
+        read(testFolder.getPath(), ALL, false, false);
+        read(testFolder.getPath(), ALL, false, true);
     }
 
     @Test
@@ -158,7 +166,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), SerialFormat.COMPRESSED_FILTERED_TSI.toString(), false);
-        read(testFolder.getPath(), ALL, false);
+        read(testFolder.getPath(), ALL, false, false);
+        read(testFolder.getPath(), ALL, false, true);
     }
 
     @Test
@@ -166,7 +175,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), SerialFormat.COMPRESSED_FILTERED_TSI.toString(), false);
-        read(testFolder.getPath(), METADATA, false);
+    	read(testFolder.getPath(), METADATA, false, false);
+    	read(testFolder.getPath(), METADATA, false, true);
     }
 
     @Test
@@ -174,7 +184,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), "6+", false);
-        read(testFolder.getPath(), ALL, false);
+        read(testFolder.getPath(), ALL, false, false);
+        read(testFolder.getPath(), ALL, false, true);
     }
 
     @Test
@@ -182,7 +193,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         write(testFolder.getPath(), "6+", false);
-        read(testFolder.getPath(), METADATA, false);
+        read(testFolder.getPath(), METADATA, false, false);
+        read(testFolder.getPath(), METADATA, false, true);
     }
 
     @Test
@@ -190,7 +202,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         writeSerialized(testFolder.getPath(), false);
-        read(testFolder.getPath(), NONE, false); // Type system is reinitialized from the persisted CAS
+        read(testFolder.getPath(), NONE, false, false); // Type system is reinitialized from the persisted CAS
+        read(testFolder.getPath(), NONE, false, true); 
     }
 
     @Test
@@ -198,7 +211,8 @@ public class BinaryCasWriterReaderTest
         throws Exception
     {
         writeSerialized(testFolder.getPath(), true);
-        read(testFolder.getPath(), NONE, true); // Type system is reinitialized from the persisted CAS
+        read(testFolder.getPath(), NONE, true, false); // Type system is reinitialized from the persisted CAS
+        read(testFolder.getPath(), NONE, true, true);
     }
 
     @Test
@@ -312,7 +326,7 @@ public class BinaryCasWriterReaderTest
         assertTrue(new File(testFolder, "example1.txt.bin").exists());
     }
 
-    public void read(String aLocation, int aMode, boolean aLoadExternal)
+    public void read(String aLocation, int aMode, boolean aLoadExternal, boolean aMergeTS)
         throws Exception
     {
         TypeSystemDescription tsd;
@@ -346,6 +360,7 @@ public class BinaryCasWriterReaderTest
                     BinaryCasReader.class,
                     BinaryCasReader.PARAM_SOURCE_LOCATION, aLocation,
                     BinaryCasReader.PARAM_PATTERNS, "*.bin",
+                    BinaryCasReader.PARAM_MERGE_TYPE_SYSTEM, aMergeTS,
                     // Allow loading only if TSD is not specified
                     BinaryCasReader.PARAM_TYPE_SYSTEM_LOCATION, 
                             aLoadExternal ? "typesystem.bin" : null);
@@ -353,6 +368,7 @@ public class BinaryCasWriterReaderTest
 
         // Test reading into CAS
         CAS cas = CasCreationUtils.createCas(tsd, null, null);
+        reader.typeSystemInit(cas.getTypeSystem());
         reader.getNext(cas);
         String refText1 = readFileToString(new File("src/test/resources/texts/example1.txt"));
         assertEquals(refText1, cas.getDocumentText());

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
             <dependency>
                 <groupId>com.github.haifengl</groupId>
                 <artifactId>smile-nlp</artifactId>
-                <version>1.2.2</version>
+                <version>1.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>


### PR DESCRIPTION
Added a parameter PARAM_MERGE_TYPESYSTEM in BinaryCasReader to make it possible to turn the merging of the typeSystems on and off. 
The original typesystem is loaded in typeSystemInit().  
Modified the tests to run read() with both cases.
