### PR TITLE
#1065: Update OpenNLP 1.8.0 ref and usage of Lemmatizer and Chunker

### DIFF
--- a/dkpro-core-opennlp-asl/pom.xml
+++ b/dkpro-core-opennlp-asl/pom.xml
@@ -28,7 +28,7 @@
   <packaging>jar</packaging>
   <name>DKPro Core ASL - OpenNLP (v ${opennlp.version}) (ASL)</name>
   <properties>
-    <opennlp.version>1.7.2</opennlp.version>
+    <opennlp.version>1.8.0</opennlp.version>
   </properties>
   <dependencies>
     <dependency>

--- a/dkpro-core-opennlp-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/opennlp/OpenNlpLemmatizer.java
+++ b/dkpro-core-opennlp-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/opennlp/OpenNlpLemmatizer.java
@@ -131,8 +131,7 @@ public class OpenNlpLemmatizer
             // Fetch the OpenNLP lemmatizer instance configured with the right model and use it to
             // tag the text
             LemmatizerME lemmatizer = modelProvider.getResource();
-            String[] encodedLemmas = lemmatizer.lemmatize(toks, tags);
-            String[] lemmas = lemmatizer.decodeLemmas(toks, encodedLemmas);
+            String[] lemmas = lemmatizer.lemmatize(toks, tags);
 
             int n = 0;
             for (Token t : tokens) {

--- a/dkpro-core-opennlp-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/opennlp/internal/CasLemmaSampleStream.java
+++ b/dkpro-core-opennlp-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/opennlp/internal/CasLemmaSampleStream.java
@@ -73,9 +73,7 @@ public class CasLemmaSampleStream
             if (t.getLemma() == null) {
                 throw new IllegalStateException("Token ["+t.getCoveredText()+"] has no lemma");
             }
-            String ses = StringUtil.getShortestEditScript(t.getCoveredText(),
-                    t.getLemma().getValue());
-            lemmas.add(ses);
+            lemmas.add(t.getLemma().getValue());
         }
         
         return new LemmaSample(words, tags, lemmas);

--- a/dkpro-core-opennlp-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/opennlp/internal/OpenNlpParserTagsetDescriptionProvider.java
+++ b/dkpro-core-opennlp-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/opennlp/internal/OpenNlpParserTagsetDescriptionProvider.java
@@ -28,6 +28,7 @@ import de.tudarmstadt.ukp.dkpro.core.api.metadata.TagsetBase;
 import opennlp.tools.ml.model.MaxentModel;
 import opennlp.tools.ml.model.SequenceClassificationModel;
 import opennlp.tools.parser.ParserModel;
+import opennlp.tools.util.TokenTag;
 
 public class OpenNlpParserTagsetDescriptionProvider
 extends TagsetBase
@@ -62,7 +63,7 @@ extends TagsetBase
     {
         Set<String> tagSet = new TreeSet<String>();
         
-        SequenceClassificationModel<String> seqModel = model.getParserChunkerModel()
+        SequenceClassificationModel<TokenTag> seqModel = model.getParserChunkerModel()
                 .getChunkerSequenceModel();
         collect(seqModel.getOutcomes(), tagSet);
         

--- a/dkpro-core-opennlp-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/opennlp/OpenNlpNamedEntityRecognizerTrainerTest.java
+++ b/dkpro-core-opennlp-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/opennlp/OpenNlpNamedEntityRecognizerTrainerTest.java
@@ -111,9 +111,9 @@ public class OpenNlpNamedEntityRecognizerTrainerTest
 
         Result results = EvalUtil.dumpResults(targetFolder, expected, actual);
         
-        assertEquals(0.321976, results.getFscore(), 0.0001);
-        assertEquals(0.874462, results.getPrecision(), 0.0001);
-        assertEquals(0.197313, results.getRecall(), 0.0001);
+        assertEquals(0.323254, results.getFscore(), 0.0001);
+        assertEquals(0.877419, results.getPrecision(), 0.0001);
+        assertEquals(0.198122, results.getRecall(), 0.0001);
     }
     
     @Before

--- a/dkpro-core-opennlp-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/opennlp/OpenNlpPosTaggerTrainerTest.java
+++ b/dkpro-core-opennlp-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/opennlp/OpenNlpPosTaggerTrainerTest.java
@@ -106,9 +106,9 @@ public class OpenNlpPosTaggerTrainerTest
 
         Result results = EvalUtil.dumpResults(targetFolder, expected, actual);
         
-        assertEquals(0.646981, results.getFscore(), 0.0001);
-        assertEquals(0.646981, results.getPrecision(), 0.0001);
-        assertEquals(0.646981, results.getRecall(), 0.0001);
+        assertEquals(0.642212, results.getFscore(), 0.0001);
+        assertEquals(0.642212, results.getPrecision(), 0.0001);
+        assertEquals(0.642212, results.getRecall(), 0.0001);
     }
     
     @Rule


### PR DESCRIPTION
Issue #1065 

**Tests in failure**

```
Results :

Failed tests: 
  OpenNlpNamedEntityRecognizerTrainerTest.test:114 expected:<0.321976> but was:<0.3232536643338175>
  OpenNlpPosTaggerTrainerTest.test:109 expected:<0.646981> but was:<0.6422120750887874>
Tests in error: 
  OpenNlpParserTest.testEnglish » OutOfMemory Java heap space

Tests run: 28, Failures: 2, Errors: 1, Skipped: 13
```