### PR TITLE
change pos.tagset for IULA Treebank model

### DIFF
--- a/dkpro-core-maltparser-asl/src/scripts/build.xml
+++ b/dkpro-core-maltparser-asl/src/scripts/build.xml
@@ -309,8 +309,8 @@
 				<entry key="DC.creator" value="Universitat Pompeu Fabra. Institut Universitari de Lingüística Aplicada (IULA)"/>
 				<entry key="DC.identifier" value="http://hdl.handle.net/10230/20407"/>
 				<entry key="DC.rights" value="http://creativecommons.org/licenses/by/3.0/"/>
-	    		<entry key="pos.tagset" value="freeling"/>
-				<entry key="dependency.tagset" value="iula"/>
+	    		<entry key="pos.tagset" value="ancora"/>
+			<entry key="dependency.tagset" value="iula"/>
 			</metadata>
 		</install-stub-and-upstream-file>
 	</target>


### PR DESCRIPTION
The pos-tagset used in the IULA Treebank (and which is used also by the Freeling tool) is actually the same as the one in the Ancora corpus. The dependency tagset however is different.