### PR TITLE
Fix RegexSegmenter: use zoneBegin parameter

### DIFF
--- a/dkpro-core-tokit-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/tokit/RegexSegmenter.java
+++ b/dkpro-core-tokit-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/tokit/RegexSegmenter.java
@@ -89,11 +89,15 @@ public class RegexSegmenter
         /* append trailing linebreak if necessary */
         text = text.endsWith("\n") ? text : text + "\n";
 
-        if (isWriteSentence()) {
-            createSentences(aJCas, text);
+        if ("".equals(text.trim())) {
+            return;
         }
 
-        createTokens(aJCas, text);
+        if (isWriteSentence()) {
+            createSentences(aJCas, text, zoneBegin);
+        }
+
+        createTokens(aJCas, text, zoneBegin);
     }
 
     /**
@@ -103,14 +107,15 @@ public class RegexSegmenter
      *            the {@link JCas}
      * @param text
      *            the text.
+     * @param zoneBegin
      */
-    private void createSentences(JCas aJCas, String text)
+    private void createSentences(JCas aJCas, String text, int zoneBegin)
     {
         Matcher sentenceBoundaryMatcher = sentenceBoundaryPattern.matcher(text);
         int previousStart = 0;
         while (sentenceBoundaryMatcher.find()) {
             int end = sentenceBoundaryMatcher.start();
-            Sentence sentence = new Sentence(aJCas, previousStart, end);
+            Sentence sentence = new Sentence(aJCas, zoneBegin + previousStart, zoneBegin + end);
             sentence.addToIndexes(aJCas);
             previousStart = sentenceBoundaryMatcher.end();
         }
@@ -123,14 +128,15 @@ public class RegexSegmenter
      *            the {@link JCas}
      * @param text
      *            the text
+     * @param zoneBegin
      */
-    private void createTokens(JCas aJCas, String text)
+    private void createTokens(JCas aJCas, String text, int zoneBegin)
     {
         Matcher tokenBoundaryMatcher = tokenBoundaryPattern.matcher(text);
         int previousStart = 0;
         while (tokenBoundaryMatcher.find()) {
             int end = tokenBoundaryMatcher.start();
-            Token token = new Token(aJCas, previousStart, end);
+            Token token = new Token(aJCas, zoneBegin + previousStart, zoneBegin + end);
             token.addToIndexes(aJCas);
             previousStart = tokenBoundaryMatcher.end();
         }

--- a/dkpro-core-tokit-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/tokit/RegexSegmenterTest.java
+++ b/dkpro-core-tokit-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/tokit/RegexSegmenterTest.java
@@ -26,6 +26,7 @@ import static org.apache.uima.fit.pipeline.SimplePipeline.runPipeline;
 import static org.apache.uima.fit.util.JCasUtil.select;
 import static org.apache.uima.fit.util.JCasUtil.selectCovered;
 
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Div;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.fit.factory.JCasFactory;
@@ -189,5 +190,40 @@ public class RegexSegmenterTest
             assertSentence(expectedSentences, select(jcas, Sentence.class));
             assertToken(expectedTokens, select(jcas, Token.class));
         }
-    }    
+    }
+
+    @Test
+    public void simpleExampleWithDivs()
+            throws Exception
+    {
+        JCas jcas = JCasFactory.createText("This is sentence 1 .\nThis is number 2 .", "en");
+        Div d = new Div(jcas, 0, 20);
+        d.addToIndexes();
+        d = new Div(jcas, 21, 39);
+        d.addToIndexes();
+
+        runPipeline(jcas,
+                createEngineDescription(RegexSegmenter.class,
+                        // Treat each line as a sentence
+                        RegexSegmenter.PARAM_SENTENCE_BOUNDARY_REGEX, "\n",
+                        // Use whitespace to detect tokens
+                        RegexSegmenter.PARAM_TOKEN_BOUNDARY_REGEX, "\\s+"));
+
+        for (Sentence s : select(jcas, Sentence.class)) {
+            for (Token t : selectCovered(Token.class, s)) {
+                System.out.printf("[%s] ", t.getCoveredText());
+            }
+            System.out.println();
+        }
+        // end::example[]
+
+        assertToken(
+                new String[] { "This", "is", "sentence", "1", ".", "This", "is", "number", "2", "." },
+                select(jcas, Token.class));
+        assertSentence(
+                new String[] {
+                        "This is sentence 1 .",
+                        "This is number 2 ." },
+                select(jcas, Sentence.class));
+    }
 }


### PR DESCRIPTION
The `RegexSegmenter` did not use the `zoneBegin` parameter. In cases where a `Div` has been added to the `JCas` (see example below), the segmentation did not work. This PR fixes this issue. 

```java
JCas jcas = JCasFactory.createText("This is sentence 1 .\nThis is number 2 .", "en");
Div d = new Div(jcas, 0, 20);
d.addToIndexes();
d = new Div(jcas, 21, 39);
d.addToIndexes();
```