### PR TITLE
#1093 - Writing to JARs fails if target location is URL-encoded

### DIFF
--- a/dkpro-core-api-io-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/io/JCasFileWriter_ImplBase.java
+++ b/dkpro-core-api-io-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/io/JCasFileWriter_ImplBase.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -163,7 +164,14 @@ public abstract class JCasFileWriter_ImplBase
         }
         else if (targetLocation.startsWith(JAR_PREFIX)) {
             if (zipOutputStream == null) {
-                zipPath = targetLocation.substring(JAR_PREFIX.length());
+                try {
+                    // Try handling URL-encoded location
+                    zipPath = URI.create(URI.create(targetLocation).getRawSchemeSpecificPart())
+                            .getSchemeSpecificPart();
+                } catch (IllegalArgumentException e) {
+                    // If the location is not properly URL-encoded, just strip the prefix.
+                    zipPath = targetLocation.substring(JAR_PREFIX.length());
+                }
                 zipEntryPrefix = "";
                 int sep = zipPath.indexOf('!');
                 if (sep > -1) {


### PR DESCRIPTION
Handle case that location is URL-encoded and fall back to assuming it is not URL-encoded if decoding fails.