### PR TITLE
Provide default values if cluster file is not provided in StanfordPosTaggerTrainer

### DIFF
--- a/dkpro-core-stanfordnlp-gpl/src/main/java/de/tudarmstadt/ukp/dkpro/core/stanfordnlp/StanfordNamedEntityRecognizerTrainer.java
+++ b/dkpro-core-stanfordnlp-gpl/src/main/java/de/tudarmstadt/ukp/dkpro/core/stanfordnlp/StanfordNamedEntityRecognizerTrainer.java
@@ -193,11 +193,12 @@ public class StanfordNamedEntityRecognizerTrainer
 
         // Load user-provided configuration
         Properties props = new Properties();
-        try (InputStream is = new FileInputStream(propertiesFile)) {
-            props.load(is);
-        }
-        catch (IOException e) {
-            throw new AnalysisEngineProcessException(e);
+        if (propertiesFile != null) {
+            try (InputStream is = new FileInputStream(propertiesFile)) {
+                props.load(is);
+            } catch (IOException e) {
+                throw new AnalysisEngineProcessException(e);
+            }
         }
 
         // Add/replace training file information

--- a/dkpro-core-stanfordnlp-gpl/src/main/java/de/tudarmstadt/ukp/dkpro/core/stanfordnlp/StanfordPosTaggerTrainer.java
+++ b/dkpro-core-stanfordnlp-gpl/src/main/java/de/tudarmstadt/ukp/dkpro/core/stanfordnlp/StanfordPosTaggerTrainer.java
@@ -70,7 +70,7 @@ public class StanfordPosTaggerTrainer
      * files if {@link #PARAM_CLUSTER_FILE} is specified.
      */
     public static final String PARAM_PARAMETER_FILE = "trainFile";
-    @ConfigurationParameter(name = PARAM_PARAMETER_FILE, mandatory = true)
+    @ConfigurationParameter(name = PARAM_PARAMETER_FILE, mandatory = false)
     private File parameterFile;
 
     /**
@@ -91,19 +91,20 @@ public class StanfordPosTaggerTrainer
         super.initialize(aContext);
         
         try {
-            String p = clusterFile.getAbsolutePath();
-            if (p.contains("(") || p.contains(")") || p.contains(",")) {
-                // The Stanford POS tagger trainer does not suppor these characters in the cluster
-                // files path. If we have those, try to copy the clusters somewhere save before
-                // training. See: https://github.com/stanfordnlp/CoreNLP/issues/255
-                File tempClusterFile = File.createTempFile("dkpro-stanford-pos-trainer",
-                        ".cluster");
-                FileUtils.copyFile(clusterFile, tempClusterFile);
-                clusterFile = tempClusterFile;
-                clusterFilesTemporary = true;
-            }
-            else {
-                clusterFilesTemporary = false;
+            clusterFilesTemporary = false;
+
+            if (clusterFile != null) {
+                String p = clusterFile.getAbsolutePath();
+                if (p.contains("(") || p.contains(")") || p.contains(",")) {
+                    // The Stanford POS tagger trainer does not support these characters in the cluster
+                    // files path. If we have those, try to copy the clusters somewhere save before
+                    // training. See: https://github.com/stanfordnlp/CoreNLP/issues/255
+                    File tempClusterFile = File.createTempFile("dkpro-stanford-pos-trainer",
+                            ".cluster");
+                    FileUtils.copyFile(clusterFile, tempClusterFile);
+                    clusterFile = tempClusterFile;
+                    clusterFilesTemporary = true;
+                }
             }
         }
         catch (IOException e) {
@@ -146,11 +147,12 @@ public class StanfordPosTaggerTrainer
         
         // Load user-provided configuration
         Properties props = new Properties();
-        try (InputStream is = new FileInputStream(parameterFile)) {
-            props.load(is);
-        }
-        catch (IOException e) {
-            throw new AnalysisEngineProcessException(e);
+        if (parameterFile != null) {
+            try (InputStream is = new FileInputStream(parameterFile)) {
+                props.load(is);
+            } catch (IOException e) {
+                throw new AnalysisEngineProcessException(e);
+            }
         }
         
         // Add/replace training file information
@@ -158,10 +160,14 @@ public class StanfordPosTaggerTrainer
                 "format=TSV,wordColumn=0,tagColumn=1," + tempData.getAbsolutePath());
         props.setProperty("model", targetLocation.getAbsolutePath());
         props.setProperty("encoding", "UTF-8");
+
         if (clusterFile != null) {
             String arch = props.getProperty("arch");
             arch = arch.replaceAll("\\$\\{distsimCluster\\}", clusterFile.getAbsolutePath());
             props.setProperty("arch", arch);
+        } else {
+            // default value from documentation: https://nlp.stanford.edu/software/pos-tagger-faq.shtml#train
+            props.setProperty("arch", "words(-1,1),unicodeshapes(-1,1),order(2),suffix(4)");
         }
 
         File tempConfig = null;


### PR DESCRIPTION
- Fix Stanford tagger trainer: provide default values if cluster file is not provided and use simple name to generate POS value
- Fix Stanford ner trainer: check if properties files has been provided
- Fix OpenNLP tagger trainer: use simple name to generate POS value