### PR TITLE
Updates in BratWriter

### DIFF
--- a/dkpro-core-castransformation-asl/bin/LICENSE.txt
+++ b/dkpro-core-castransformation-asl/bin/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dkpro-core-castransformation-asl/bin/pom.xml
+++ b/dkpro-core-castransformation-asl/bin/pom.xml
@@ -1,0 +1,77 @@
+<!--
+  Copyright 2017
+  Ubiquitous Knowledge Processing (UKP) Lab
+  Technische Universität Darmstadt
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>de.tudarmstadt.ukp.dkpro.core-asl</artifactId>
+    <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+    <version>1.9.0-SNAPSHOT</version>
+    <relativePath>../dkpro-core-asl</relativePath>
+  </parent>
+  <artifactId>de.tudarmstadt.ukp.dkpro.core.castransformation-asl</artifactId>
+  <packaging>jar</packaging>
+  <name>DKPro Core ASL - CAS Transformation (ASL)</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimafit-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.api.metadata-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.api.transform-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.testing-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.io.text-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.io.xmi-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.tokit-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/dkpro-core-castransformation-asl/bin/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/.gitignore
+++ b/dkpro-core-castransformation-asl/bin/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/.gitignore
@@ -1,0 +1,3 @@
+/ApplyChangesAnnotator.class
+/Backmapper.class
+/package-info.class

--- a/dkpro-core-castransformation-asl/bin/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/.gitignore
+++ b/dkpro-core-castransformation-asl/bin/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/.gitignore
@@ -1,0 +1,2 @@
+/AlignmentStorage$Key.class
+/AlignmentStorage.class

--- a/dkpro-core-castransformation-asl/bin/src/test/java/de/tudarmstadt/ukp/dkpro/core/castransformation/.gitignore
+++ b/dkpro-core-castransformation-asl/bin/src/test/java/de/tudarmstadt/ukp/dkpro/core/castransformation/.gitignore
@@ -1,0 +1,4 @@
+/ApplyChangesBackmapperTest$AssertFeatureStructureCount.class
+/ApplyChangesBackmapperTest$CreateFeatureStructure.class
+/ApplyChangesBackmapperTest$SofaDeleteAnnotator.class
+/ApplyChangesBackmapperTest.class

--- a/dkpro-core-castransformation-asl/bin/src/test/resources/input.txt
+++ b/dkpro-core-castransformation-asl/bin/src/test/resources/input.txt
@@ -1,0 +1,2 @@
+Lumbo labi bumbo nabi noo. Labibi humba doopi jamba Too. Mekoman jalla hembembel! Labumbu jakka
+lembi nabi. Humba jumbaba tumba Jalla Jamba.

--- a/dkpro-core-castransformation-asl/bin/src/test/resources/log4j.properties
+++ b/dkpro-core-castransformation-asl/bin/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=WARN,development
+
+log4j.appender.development=org.apache.log4j.ConsoleAppender
+log4j.appender.development.layout=org.apache.log4j.PatternLayout
+log4j.appender.development.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %5p [%t] (%C{1}) - %m%n
+
+log4j.logger.de.tudarmstadt.ukp = DEBUG
+log4j.logger.de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator = TRACE

--- a/dkpro-core-castransformation-asl/bin/src/test/resources/output.txt
+++ b/dkpro-core-castransformation-asl/bin/src/test/resources/output.txt
@@ -1,0 +1,297 @@
+======== CAS 0 begin ==================================
+
+-------- View _InitialView begin ----------------------------------
+
+DocumentMetaData
+   sofa: _InitialView
+   begin: 0
+   end: 141
+   language: "en"
+   documentTitle: "input.txt"
+   documentId: "input.txt"
+   isLastSegment: false
+
+CAS-Text:
+Lumbo labi bumbo nabi noo. Labibi humba doopi jamba Too. Mekoman jalla hembembel! Labumbu jakka
+lembi nabi. Humba jumbaba tumba Jalla Jamba.
+
+[Lumbo labi bumbo nabi noo.]
+SofaChangeAnnotation
+   sofa: _InitialView
+   begin: 0
+   end: 26
+   operation: "delete"
+[Labibi humba doopi jamba Too.]
+Sentence
+   sofa: _InitialView
+   begin: 27
+   end: 56
+[Labibi]
+Token
+   sofa: _InitialView
+   begin: 27
+   end: 33
+[humba]
+Token
+   sofa: _InitialView
+   begin: 34
+   end: 39
+[doopi]
+Token
+   sofa: _InitialView
+   begin: 40
+   end: 45
+[jamba]
+Token
+   sofa: _InitialView
+   begin: 46
+   end: 51
+[Too]
+Token
+   sofa: _InitialView
+   begin: 52
+   end: 55
+[.]
+Token
+   sofa: _InitialView
+   begin: 55
+   end: 56
+[Mekoman jalla hembembel!]
+Sentence
+   sofa: _InitialView
+   begin: 57
+   end: 81
+[Mekoman]
+Token
+   sofa: _InitialView
+   begin: 57
+   end: 64
+[jalla]
+Token
+   sofa: _InitialView
+   begin: 65
+   end: 70
+[hembembel]
+Token
+   sofa: _InitialView
+   begin: 71
+   end: 80
+[!]
+Token
+   sofa: _InitialView
+   begin: 80
+   end: 81
+[Labumbu jakka
+lembi nabi.]
+Sentence
+   sofa: _InitialView
+   begin: 82
+   end: 107
+[Labumbu]
+Token
+   sofa: _InitialView
+   begin: 82
+   end: 89
+[jakka]
+Token
+   sofa: _InitialView
+   begin: 90
+   end: 95
+[lembi]
+Token
+   sofa: _InitialView
+   begin: 96
+   end: 101
+[nabi]
+Token
+   sofa: _InitialView
+   begin: 102
+   end: 106
+[.]
+Token
+   sofa: _InitialView
+   begin: 106
+   end: 107
+[Humba jumbaba tumba Jalla Jamba.]
+Sentence
+   sofa: _InitialView
+   begin: 108
+   end: 140
+[Humba]
+Token
+   sofa: _InitialView
+   begin: 108
+   end: 113
+[jumbaba]
+Token
+   sofa: _InitialView
+   begin: 114
+   end: 121
+[tumba]
+Token
+   sofa: _InitialView
+   begin: 122
+   end: 127
+[Jalla]
+Token
+   sofa: _InitialView
+   begin: 128
+   end: 133
+[Jamba]
+Token
+   sofa: _InitialView
+   begin: 134
+   end: 139
+[.]
+Token
+   sofa: _InitialView
+   begin: 139
+   end: 140
+-------- View _InitialView end ----------------------------------
+
+-------- View TargetView begin ----------------------------------
+
+DocumentMetaData
+   sofa: TargetView
+   begin: 0
+   end: 115
+   language: "en"
+   documentTitle: "input.txt"
+   documentId: "input.txt"
+   isLastSegment: false
+
+CAS-Text:
+ Labibi humba doopi jamba Too. Mekoman jalla hembembel! Labumbu jakka
+lembi nabi. Humba jumbaba tumba Jalla Jamba.
+
+[Labibi humba doopi jamba Too.]
+Sentence
+   sofa: TargetView
+   begin: 1
+   end: 30
+[Labibi]
+Token
+   sofa: TargetView
+   begin: 1
+   end: 7
+[humba]
+Token
+   sofa: TargetView
+   begin: 8
+   end: 13
+[doopi]
+Token
+   sofa: TargetView
+   begin: 14
+   end: 19
+[jamba]
+Token
+   sofa: TargetView
+   begin: 20
+   end: 25
+[Too]
+Token
+   sofa: TargetView
+   begin: 26
+   end: 29
+[.]
+Token
+   sofa: TargetView
+   begin: 29
+   end: 30
+[Mekoman jalla hembembel!]
+Sentence
+   sofa: TargetView
+   begin: 31
+   end: 55
+[Mekoman]
+Token
+   sofa: TargetView
+   begin: 31
+   end: 38
+[jalla]
+Token
+   sofa: TargetView
+   begin: 39
+   end: 44
+[hembembel]
+Token
+   sofa: TargetView
+   begin: 45
+   end: 54
+[!]
+Token
+   sofa: TargetView
+   begin: 54
+   end: 55
+[Labumbu jakka
+lembi nabi.]
+Sentence
+   sofa: TargetView
+   begin: 56
+   end: 81
+[Labumbu]
+Token
+   sofa: TargetView
+   begin: 56
+   end: 63
+[jakka]
+Token
+   sofa: TargetView
+   begin: 64
+   end: 69
+[lembi]
+Token
+   sofa: TargetView
+   begin: 70
+   end: 75
+[nabi]
+Token
+   sofa: TargetView
+   begin: 76
+   end: 80
+[.]
+Token
+   sofa: TargetView
+   begin: 80
+   end: 81
+[Humba jumbaba tumba Jalla Jamba.]
+Sentence
+   sofa: TargetView
+   begin: 82
+   end: 114
+[Humba]
+Token
+   sofa: TargetView
+   begin: 82
+   end: 87
+[jumbaba]
+Token
+   sofa: TargetView
+   begin: 88
+   end: 95
+[tumba]
+Token
+   sofa: TargetView
+   begin: 96
+   end: 101
+[Jalla]
+Token
+   sofa: TargetView
+   begin: 102
+   end: 107
+[Jamba]
+Token
+   sofa: TargetView
+   begin: 108
+   end: 113
+[.]
+Token
+   sofa: TargetView
+   begin: 113
+   end: 114
+-------- View TargetView end ----------------------------------
+
+======== CAS 0 end ==================================
+
+

--- a/dkpro-core-io-brat-asl/pom.xml
+++ b/dkpro-core-io-brat-asl/pom.xml
@@ -77,4 +77,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <version>1.10.1-TALN</version>
 </project>

--- a/dkpro-core-io-brat-asl/pom.xml
+++ b/dkpro-core-io-brat-asl/pom.xml
@@ -77,5 +77,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <version>1.10.1-TALN</version>
+  <version>1.10.1-taln</version>
 </project>

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
@@ -19,7 +19,10 @@ package de.tudarmstadt.ukp.dkpro.core.io.brat;
 
 import static org.apache.uima.fit.util.JCasUtil.selectAll;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
@@ -46,7 +49,9 @@ import org.apache.uima.cas.TypeSystem;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.descriptor.ConfigurationParameter;
 import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.fit.util.CasUtil;
 import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.ResourceInitializationException;
 
@@ -103,6 +108,14 @@ public class BratWriter extends JCasFileWriter_ImplBase
     private String filenameSuffix;
     
     /**
+     * Specify the suffix of output files. Default value <code>.ann</code>. If the suffix is not
+     * needed, provide an empty string as value.
+     */
+    public static final String PARAM_HTML_TEMPLANTE = "htmlTemplate";
+    @ConfigurationParameter(name = PARAM_HTML_TEMPLANTE , mandatory = false, defaultValue = "template.html")
+    private String htmlTemplate;
+
+    /**
      * Types that will not be written to the exported file.
      */
     public static final String PARAM_EXCLUDE_TYPES = "excludeTypes";
@@ -111,12 +124,13 @@ public class BratWriter extends JCasFileWriter_ImplBase
     private Set<String> excludeTypes;
 
     /**
-     * Types that are text annotations (aka entities or spans).
+     * Types that are text annotations (aka entities or spans). Each of them includes a 
+     * type (or parent type) after it ":" and element to extract  use pipes to make a chain of elements.
      */
-    public static final String PARAM_TEXT_ANNOTATION_TYPES = "spanTypes";
+    public static final String PARAM_TEXT_ANNOTATION_TYPES = "spanTypesVals";
     @ConfigurationParameter(name = PARAM_TEXT_ANNOTATION_TYPES, mandatory = true, defaultValue = { 
 //            "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence",
-//            "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+//           "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token:Lemma|Value",
 //            "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS",
 //            "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma",
 //            "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Stem",
@@ -125,7 +139,7 @@ public class BratWriter extends JCasFileWriter_ImplBase
 //            "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemArg", 
 //            "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemPred" 
             })
-    private Set<String> spanTypes;
+    private String[] spanTypesVals;
 
     /**
      * Types that are relations. It is mandatory to provide the type name followed by two feature
@@ -205,7 +219,7 @@ public class BratWriter extends JCasFileWriter_ImplBase
     private int nextAttributeId;
     private int nextPaletteIndex;
     private Map<FeatureStructure, String> spanIdMap;
-    
+    private Map<String,String> spanTypes;
     private BratConfiguration conf;
     
     private Set<String> warnings;
@@ -218,7 +232,15 @@ public class BratWriter extends JCasFileWriter_ImplBase
         conf = new BratConfiguration();
         
         warnings = new LinkedHashSet<String>();
-        
+        spanTypes= new HashMap<>();
+        for (String s: spanTypesVals){
+        	String[] parts=s.split(":");
+        	if (parts.length>1){
+        		spanTypes.put(parts[0],parts[1]);
+        	} else {
+        		spanTypes.put(parts[0],"");
+        	}
+        }
         parsedRelationTypes = new HashMap<>();
         for (String rel : relationTypes) {
             RelationParam p = RelationParam.parse(rel);
@@ -306,32 +328,44 @@ public class BratWriter extends JCasFileWriter_ImplBase
 
         // Go through all the annotations but only handle the ones that have no references to
         // other annotations.
+        for (String s: spanTypesVals){
+        	String[] parts=s.split(":");
+            String currentType=parts[0];
+            for (FeatureStructure fs : selectAll(aJCas)) {
+                String typeName=fs.getType().getName();
+                String superType = fs.getCAS().getTypeSystem().getParent(fs.getType()).getName();
+                if (currentType.equalsIgnoreCase(typeName) || currentType.equalsIgnoreCase(superType)) {
+                    writeTextAnnotation(doc, (AnnotationFS) fs);
+                }          
+        	}
+        }
         for (FeatureStructure fs : selectAll(aJCas)) {
             // Skip document annotation
             if (fs == aJCas.getDocumentAnnotationFs()) {
                 continue;
             }
-            
+            String typeName=fs.getType().getName();
+            String superType = fs.getCAS().getTypeSystem().getParent(fs.getType()).getName();
             // Skip excluded types
-            if (excludeTypes.contains(fs.getType().getName())) {
+            if (excludeTypes.contains(typeName) || excludeTypes.contains(superType) ) {
                 getLogger().debug("Excluding [" + fs.getType().getName() + "]");
                 continue;
             }
             
-            if (spanTypes.contains(fs.getType().getName())) {
-                writeTextAnnotation(doc, (AnnotationFS) fs);
+            if (spanTypes.containsKey(typeName) || spanTypes.containsKey(superType)) {
+               // writeTextAnnotation(doc, (AnnotationFS) fs);
             }
-            else if (parsedRelationTypes.containsKey(fs.getType().getName())) {
+            else if (parsedRelationTypes.containsKey(typeName)|| parsedRelationTypes.containsKey(superType)) {
                 relationFS.add(fs);
             }
-            else if (hasNonPrimitiveFeatures(fs) && (fs instanceof AnnotationFS)) {
+//            else if (hasNonPrimitiveFeatures(fs) && (fs instanceof AnnotationFS)) {
 //            else if (parsedEventTypes.containsKey(fs.getType().getName())) {
-                BratEventAnnotation event = writeEventAnnotation(doc, (AnnotationFS) fs);
-                eventFS.put(event, fs);
-            }
+//                BratEventAnnotation event = writeEventAnnotation(doc, (AnnotationFS) fs);
+//                eventFS.put(event, fs);
+//            }
             else if (fs instanceof AnnotationFS) {
                 warnings.add("Assuming annotation type ["+fs.getType().getName()+"] is span");
-                writeTextAnnotation(doc, (AnnotationFS) fs);
+             // NO    writeTextAnnotation(doc, (AnnotationFS) fs);
             }
             else {
                 warnings.add("Skipping annotation with type ["+fs.getType().getName()+"]");
@@ -358,7 +392,8 @@ public class BratWriter extends JCasFileWriter_ImplBase
         case ".json":
             String template ;
             if (filenameSuffix.equals(".html")) {
-                template = IOUtils.toString(getClass().getResource("html/template.html"));
+            	InputStream it=new FileInputStream(htmlTemplate)  ; 
+                template = IOUtils.toString(it,"UTF-8");
             }
             else {
                 template = "{ \"collData\" : ##COLL-DATA## , \"docData\" : ##DOC-DATA## }";
@@ -562,7 +597,9 @@ public class BratWriter extends JCasFileWriter_ImplBase
     private void writeRelationAnnotation(BratAnnotationDocument aDoc, FeatureStructure aFS)
     {
         RelationParam rel = parsedRelationTypes.get(aFS.getType().getName());
-        
+        if (rel== null ) {// then is the parent type
+        	rel=parsedRelationTypes.get(aFS.getCAS().getTypeSystem().getParent(aFS.getType()).getName());
+        }
         FeatureStructure arg1 = aFS.getFeatureValue(aFS.getType().getFeatureByBaseName(
                 rel.getArg1()));
         FeatureStructure arg2 = aFS.getFeatureValue(aFS.getType().getFeatureByBaseName(
@@ -581,15 +618,25 @@ public class BratWriter extends JCasFileWriter_ImplBase
 
         String superType = getBratType(aFS.getCAS().getTypeSystem().getParent(aFS.getType()));
         String type = getBratType(aFS.getType());
-        
-        BratRelationAnnotation anno = new BratRelationAnnotation(nextRelationAnnotationId,
-                type, rel.getArg1(), arg1Id, rel.getArg2(), arg2Id);
+        String value=type;
+       if (rel.getSubcat()!=""){
+    	   value=aFS.getFeatureValueAsString(aFS.getType().getFeatureByBaseName(rel.getSubcat()));
+   	    }
+       
+       BratRelationAnnotation anno = new BratRelationAnnotation(nextRelationAnnotationId,
+                value, rel.getArg1(), arg1Id, rel.getArg2(), arg2Id);
         nextRelationAnnotationId++;
         
-        conf.addRelationDecl(superType, type, rel.getArg1(), rel.getArg2());
-        
+        conf.addRelationDecl(superType, value, rel.getArg1(), rel.getArg2());
+
+        if (enableTypeMappings){
+//      	 conf.addLabelDecl(type,type,type.substring(0, 2),type.substring(0, 1));
+      	    conf.addLabelDecl(value,value);
+       }else {        
         conf.addLabelDecl(anno.getType(), aFS.getType().getShortName(), aFS.getType()
                 .getShortName().substring(0, 1));
+       }
+     
         
         aDoc.addAnnotation(anno);
         
@@ -604,16 +651,44 @@ public class BratWriter extends JCasFileWriter_ImplBase
     {
         String superType = getBratType(aFS.getCAS().getTypeSystem().getParent(aFS.getType()));
         String type = getBratType(aFS.getType());
-        
-        BratTextAnnotation anno = new BratTextAnnotation(nextTextAnnotationId, type,
+        // check if the type has  a value to display, replace the the type by the value
+        // do it similar as with declarations that looks for the value
+        String spanData="";
+        String value=type;
+        if (spanTypes.containsKey(aFS.getType().getName())) {
+        	spanData=spanTypes.get(aFS.getType().getName());
+        } else  if (spanTypes.containsKey(aFS.getCAS().getTypeSystem().getParent(aFS.getType()).getName() ))  {
+        	spanData=spanTypes.get(aFS.getCAS().getTypeSystem().getParent(aFS.getType()).getName() );
+        }
+        try {
+        if (!spanData.equalsIgnoreCase("")){
+        	String [] splits=spanData.split("\\|");
+        	if (splits.length>1){
+        	FeatureStructure currentAnnot = aFS.getFeatureValue(aFS.getType().getFeatureByBaseName(splits[0]));
+        	for (int f=1;f<splits.length-1;f++){     		
+        		currentAnnot = currentAnnot.getFeatureValue(currentAnnot.getType().getFeatureByBaseName(splits[f]));
+        	}
+        	value= currentAnnot.getFeatureValueAsString(currentAnnot.getType().getFeatureByBaseName(splits[splits.length-1]));
+        }  	else {
+        	value=aFS.getFeatureValueAsString(aFS.getType().getFeatureByBaseName(splits[0]));
+        	}
+        } 
+        } catch (Exception E){
+        	System.out.println("failed to get "+ spanData +"from "+ type);
+        	E.printStackTrace();
+        }
+        BratTextAnnotation anno = new BratTextAnnotation(nextTextAnnotationId, value,
                 aFS.getBegin(), aFS.getEnd(), aFS.getCoveredText());
         nextTextAnnotationId++;
 
-        conf.addEntityDecl(superType, type);
-        
-        conf.addLabelDecl(anno.getType(), aFS.getType().getShortName(), aFS.getType()
+        conf.addEntityDecl(superType, value);
+        if (enableTypeMappings){
+//       	 conf.addLabelDecl(type,type,type.substring(0, 2),type.substring(0, 1));
+       	    conf.addLabelDecl(value,value);
+        }else {
+         conf.addLabelDecl(anno.getType(), aFS.getType().getShortName(), aFS.getType()
                 .getShortName().substring(0, 1));
-
+        }
         if (!conf.hasDrawingDecl(anno.getType())) {
             conf.addDrawingDecl(new BratTextAnnotationDrawingDecl(anno.getType(), "black",
                     palette[nextPaletteIndex % palette.length]));
@@ -622,7 +697,7 @@ public class BratWriter extends JCasFileWriter_ImplBase
         
         aDoc.addAnnotation(anno);
         
-        writeAttributes(anno, aFS);
+        // writeAttributes(anno, aFS);
         
         spanIdMap.put(aFS, anno.getId());
     }

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
@@ -44,11 +44,11 @@ public class BratTextAnnotation
     private final String text;
 
     public BratTextAnnotation(int aId, String aType, int aBegin, int aEnd, String aText)
-    {
-        this("T" + aId, aType, aBegin, aEnd, aText);
+    {    	
+        this("T" + String.format("%04d", aId), aType, aBegin, aEnd, aText);
     }
 
-    public BratTextAnnotation(String aId, String aType, int aBegin, int aEnd, String aText)
+    private BratTextAnnotation(String aId, String aType, int aBegin, int aEnd, String aText)
     {
         super(aId, aType);
         begin = aBegin;

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
         </repository>
         -->
         <!-- For SNAPSHOTs from the DKPro family -->
-        <!--
         <repository>
             <id>ukp-oss-snapshots</id>
             <url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots</url>
@@ -98,7 +97,6 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        -->
     </repositories>
 	<pluginRepositories>
         <!-- For UIMA/uimaFIT RCs -->


### PR DESCRIPTION
Well.. I would like the pull request to be only 2 files, the ones of brat.. but...
I did some changes (improvements) to BratWriter.  
The idea was to solve some problems I found:

1.  add a parameter to indicate where the html template is. With the current version was inside the jar. So it could not be customizable
2. Change the way that is used to extract the information. In the previous version there was a kind of defualt option extracting everything.... So the changes include
- List of elements to extract mandatory
- The order of the elements to extract influences how they are exported (this can be combined with a change to the brat javascript to force that brat represents them in the same sorting order. It was difficult to understand the output when the annotations over a token are sorted according to "size". Because the same annotation layer was in different positions over different tokens.
- Indication of which field to display for each type. It was very frustrating to have "token" for each word in order to display dependencies, now each annotations can decide which field to display (for the moment only one field is allowed and annotation can appear only once (but I think is easy to extend this))
- Parent Types. Extend the usage of parent types. For example to allow the representation of all kinds of dependencies and avoid to have just "dependency" and solved an error with "root"
 for example here there is a the ouptut with this code:
![image](https://user-images.githubusercontent.com/2848623/34037760-49417b18-e18a-11e7-8a12-50c0756c7d1e.png)

instead of I could get with the original component
![image](https://user-images.githubusercontent.com/2848623/34038271-205bf492-e18c-11e7-951e-87ffafe337d9.png)


