### PR TITLE
prevents NullPointerException when syntax columns are empty, fix 1188

### DIFF
--- a/dkpro-core-io-conll-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/conll/Conll2012Reader.java
+++ b/dkpro-core-io-conll-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/conll/Conll2012Reader.java
@@ -445,7 +445,9 @@ public class Conll2012Reader
             Sentence sentence = new Sentence(aJCas, sentenceBegin, sentenceEnd);
             sentence.addToIndexes();
             
-            converter.convertPennTree(sentence, PennTreeUtils.parsePennTree(parse.toString()));
+            if (readConstituent) {
+                converter.convertPennTree(sentence, PennTreeUtils.parsePennTree(parse.toString()));
+            }
 
             // Once sentence per line.
             doc.add("\n");


### PR DESCRIPTION
Fix for #1188.

I didn't commit the test because I can't run it, because other tests fail (see below).

```
=== testConvertWordVectorsToBinaryCaseSensitive =====================
Failed to instantiate SLF4J LoggerFactory
Reported exception:
java.lang.NoClassDefFoundError: org/apache/log4j/Level
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:412)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
```