### PR TITLE
#825 - Upgrade Illinois components

### DIFF
--- a/dkpro-core-lbj-asl/pom.xml
+++ b/dkpro-core-lbj-asl/pom.xml
@@ -30,7 +30,7 @@
   <name>DKPro Core ASL - Illinois Cognitive Computation Group NLP (v ${illinois-cogcomp-nlp.version}) (academic use)</name>
   <url>https://dkpro.github.io/dkpro-core/</url>
   <properties>
-    <illinois-cogcomp-nlp.version>4.0.6</illinois-cogcomp-nlp.version>
+    <illinois-cogcomp-nlp.version>4.0.7</illinois-cogcomp-nlp.version>
     <maven.surefire.heap>6g</maven.surefire.heap>
   </properties>
   <dependencies>
@@ -97,13 +97,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!--
-      <dependency>
-      <groupId>edu.illinois.cs.cogcomp</groupId>
-      <artifactId>illinois-srl</artifactId>
-      <version>5.1.11</version>
-      </dependency>
-    -->
     <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.api.metadata-asl</artifactId>

--- a/dkpro-core-lbj-asl/pom.xml
+++ b/dkpro-core-lbj-asl/pom.xml
@@ -47,6 +47,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>edu.illinois.cs.cogcomp</groupId>
       <artifactId>illinois-pos</artifactId>
       <version>${illinois-cogcomp-nlp.version}</version>
@@ -137,11 +141,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dkpro-core-lbj-asl/pom.xml
+++ b/dkpro-core-lbj-asl/pom.xml
@@ -27,11 +27,11 @@
   </parent>
   <artifactId>de.tudarmstadt.ukp.dkpro.core.lbj-asl</artifactId>
   <packaging>jar</packaging>
-  <name>DKPro Core ASL - Illinois Cognitive Computation Group NLP (v ${illinois-cogcomp-nlp.version})</name>
+  <name>DKPro Core ASL - Illinois Cognitive Computation Group NLP (v ${illinois-cogcomp-nlp.version}) (academic use)</name>
   <url>https://dkpro.github.io/dkpro-core/</url>
   <properties>
-    <illinois-cogcomp-nlp.version>3.0.72</illinois-cogcomp-nlp.version>
-    <maven.surefire.heap>4g</maven.surefire.heap>
+    <illinois-cogcomp-nlp.version>4.0.6</illinois-cogcomp-nlp.version>
+    <maven.surefire.heap>6g</maven.surefire.heap>
   </properties>
   <dependencies>
     <dependency>
@@ -54,13 +54,7 @@
     <dependency>
       <groupId>edu.illinois.cs.cogcomp</groupId>
       <artifactId>LBJava</artifactId>
-      <version>1.2.24</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>weka-stable</artifactId>
-          <groupId>nz.ac.waikato.cms.weka</groupId>
-        </exclusion>
-      </exclusions>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>edu.illinois.cs.cogcomp</groupId>
@@ -76,6 +70,12 @@
       <groupId>edu.illinois.cs.cogcomp</groupId>
       <artifactId>illinois-ner</artifactId>
       <version>${illinois-cogcomp-nlp.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>edu.stanford.nlp</groupId>
+          <artifactId>stanford-corenlp</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>edu.illinois.cs.cogcomp</groupId>
@@ -90,6 +90,10 @@
         <exclusion>
           <artifactId>stanford-corenlp</artifactId>
           <groupId>edu.stanford.nlp</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>mysql</groupId>
+          <artifactId>mysql-connector-java</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/dkpro-core-lbj-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/lbj/IllinoisStatefulSegmenter.java
+++ b/dkpro-core-lbj-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/lbj/IllinoisStatefulSegmenter.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.dkpro.core.lbj;
 
 import org.apache.uima.UimaContext;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
 import org.apache.uima.fit.descriptor.ResourceMetaData;
 import org.apache.uima.fit.descriptor.TypeCapability;
 import org.apache.uima.jcas.JCas;
@@ -42,6 +43,20 @@ import eu.openminted.share.annotations.api.DocumentationResource;
 public class IllinoisStatefulSegmenter
     extends SegmenterBase
 {
+    /**
+     * Split tokens on dashes.
+     */
+    public static final String PARAM_SPLIT_ON_DASH = "splitOnDash";
+    @ConfigurationParameter(name = PARAM_SPLIT_ON_DASH, mandatory = true, defaultValue = "true")
+    private boolean splitOnDash;
+
+    /**
+     * Split if there are two newlines in a row (ignoring additional newlines).
+     */
+    public static final String PARAM_SPLIT_ON_SECOND_NL = "splitOnSecondNL";
+    @ConfigurationParameter(name = PARAM_SPLIT_ON_SECOND_NL, mandatory = true, defaultValue = "false")
+    private boolean splitOnSecondNL;
+
     private Tokenizer tokenizer;
     
     @Override
@@ -50,7 +65,7 @@ public class IllinoisStatefulSegmenter
     {
         super.initialize(aContext);
         
-        tokenizer = new StatefulTokenizer();
+        tokenizer = new StatefulTokenizer(splitOnDash, splitOnSecondNL);
     }
     
     @Override

--- a/dkpro-core-lbj-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/lbj/IllinoisPosTaggerTest.java
+++ b/dkpro-core-lbj-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/lbj/IllinoisPosTaggerTest.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
 import static org.apache.uima.fit.util.JCasUtil.select;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.uima.analysis_engine.AnalysisEngine;
@@ -41,7 +42,7 @@ public class IllinoisPosTaggerTest
         throws Exception
     {
         File tempFile = File.createTempFile("dkpro", ".txt");
-        FileUtils.write(tempFile, "This is a test .");
+        FileUtils.write(tempFile, "This is a test .", StandardCharsets.UTF_8);
         POSTagPlain.main(new String[] { tempFile.getAbsolutePath() });
     }
     

--- a/dkpro-core-lbj-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/lbj/IllinoisPosTaggerTest.java
+++ b/dkpro-core-lbj-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/lbj/IllinoisPosTaggerTest.java
@@ -21,7 +21,6 @@ import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
 import static org.apache.uima.fit.util.JCasUtil.select;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.uima.analysis_engine.AnalysisEngine;
@@ -42,7 +41,7 @@ public class IllinoisPosTaggerTest
         throws Exception
     {
         File tempFile = File.createTempFile("dkpro", ".txt");
-        FileUtils.write(tempFile, "This is a test .", StandardCharsets.UTF_8);
+        FileUtils.write(tempFile, "This is a test .", "UTF-8");
         POSTagPlain.main(new String[] { tempFile.getAbsolutePath() });
     }
     

--- a/dkpro-core-lbj-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/lbj/IllinoisStatefulSegmenterTest.java
+++ b/dkpro-core-lbj-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/lbj/IllinoisStatefulSegmenterTest.java
@@ -32,6 +32,6 @@ public class IllinoisStatefulSegmenterTest
     {
         AnalysisEngineDescription aed = createEngineDescription(IllinoisStatefulSegmenter.class);
 
-        SegmenterHarness.run(aed, "de.4", "en.9", "ar.1", "zh.1", "zh.2");
+        SegmenterHarness.run(aed, "de.4", "en.1", "en.9", "ar.1", "zh.1", "zh.2");
     }
 }

--- a/dkpro-core-lbj-asl/src/test/resources/log4j.properties
+++ b/dkpro-core-lbj-asl/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=WARN,development
+
+log4j.appender.development=org.apache.log4j.ConsoleAppender
+log4j.appender.development.layout=org.apache.log4j.PatternLayout
+log4j.appender.development.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %5p [%t] (%C{1}) - %m%n
+
+log4j.logger.de.tudarmstadt.ukp = DEBUG
+log4j.logger.de.tudarmstadt.ukp.dkpro.core.api.resources.ResourceObjectProviderBase = INFO


### PR DESCRIPTION
- Upgrade to CogComp 4.0.7
- Adust stateful segmenter unit test
- Exclude GPL dependencies
- Add note to POM about academic-only use
- Removed explicit LBJava dependency
- Increase memory for unit tests