### PR TITLE
Issue 1244: Restore alignment data for Backmapper after a CAS restore

### DIFF
--- a/dkpro-core-api-transform-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/transform/SofaChangeOperations.java
+++ b/dkpro-core-api-transform-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/transform/SofaChangeOperations.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.dkpro.core.api.transform;
+
+/**
+ * Constants representing the valid operations in a SofaChangeAnnotation.
+ *
+ * @since 1.9.3
+ */
+
+public final class SofaChangeOperations {
+
+    public static final String OP_INSERT = "insert";
+    public static final String OP_REPLACE = "replace";
+    public static final String OP_DELETE = "delete";
+
+}

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
@@ -17,18 +17,20 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.castransformation;
 
-import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentFactory;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
-import eu.openminted.share.annotations.api.DocumentationResource;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.cas.CASException;
 import org.apache.uima.fit.component.JCasAnnotator_ImplBase;
 import org.apache.uima.fit.descriptor.ResourceMetaData;
 import org.apache.uima.fit.descriptor.TypeCapability;
 import org.apache.uima.jcas.JCas;
+
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentFactory;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
+
+import eu.openminted.share.annotations.api.DocumentationResource;
 
 /**
  * Applies changes annotated using a {@link SofaChangeAnnotation}.

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
@@ -51,10 +51,6 @@ public class ApplyChangesAnnotator
 {
     public static final String VIEW_SOURCE = "source";
     public static final String VIEW_TARGET = "target";
-    
-    public static final String OP_INSERT = "insert";
-    public static final String OP_REPLACE = "replace";
-    public static final String OP_DELETE = "delete";
 
     @Override
     public void process(JCas aJCas)

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
@@ -17,25 +17,18 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.castransformation;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentBuild;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
+import eu.openminted.share.annotations.api.DocumentationResource;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.cas.CASException;
-import org.apache.uima.cas.FSIndex;
-import org.apache.uima.cas.FSIterator;
 import org.apache.uima.fit.component.JCasAnnotator_ImplBase;
 import org.apache.uima.fit.descriptor.ResourceMetaData;
 import org.apache.uima.fit.descriptor.TypeCapability;
 import org.apache.uima.jcas.JCas;
-import org.apache.uima.jcas.tcas.Annotation;
-
-import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
-import eu.openminted.share.annotations.api.DocumentationResource;
 
 /**
  * Applies changes annotated using a {@link SofaChangeAnnotation}.
@@ -80,76 +73,7 @@ public class ApplyChangesAnnotator
 
     protected void applyChanges(JCas aSourceView, JCas aTargetView)
     {
-        FSIndex<Annotation> idx = aSourceView.getAnnotationIndex(SofaChangeAnnotation.type);
-
-        getLogger().info("Found " + idx.size() + " changes");
-
-        // Apply all the changes
-        AlignedString as = new AlignedString(aSourceView.getDocumentText());
-
-        // Collect all those edits that are going to be executed.
-        //
-        // | A | C1 C2 R
-        // BBBBBB + - -
-        // BBBBBBBBBB + + +
-        // BBBBBBBBBBBBBBBBB + + +
-        // BBBBBBB - + -
-        // BBBBBBBBBBBBB - + -
-        // BBBBBBBB - + -
-        //
-        if (idx.size() > 0) {
-            List<SofaChangeAnnotation> edits = new ArrayList<SofaChangeAnnotation>();
-            {
-                // Get an iterator over all the change annotations. Per UIMA default
-                // this iterator is sorted first by begin and then by end offsets.
-                // We will make use of this fact here to skip change annotations that
-                // are covered by others. The earliest longest change wins - this means
-                // the one with the smallest begin offset and the largest end offset.
-                FSIterator<Annotation> it = idx.iterator();
-
-                SofaChangeAnnotation top = (SofaChangeAnnotation) it.get();
-                edits.add(top);
-                it.moveToNext();
-                while (it.isValid()) {
-                    SofaChangeAnnotation b = (SofaChangeAnnotation) it.get();
-                    if (((top.getBegin() <= b.getBegin()) && // C1
-                            (top.getEnd() > b.getBegin()) // C2
-                            )
-                            || ((top.getBegin() == b.getBegin()) && (top.getEnd() == b.getEnd()))) {
-                        // Found annotation covering current annotation. Skipping
-                        // current annotation.
-                    }
-                    else {
-                        top = b;
-                        edits.add(top);
-                    }
-                    it.moveToNext();
-                }
-            }
-
-            // If we remove or add stuff all offsets right of the change location
-            // will change and thus the offsets in the change annotation are no
-            // longer valid. If we move from right to left it works better because
-            // the left offsets remain stable.
-            Collections.reverse(edits);
-            for (SofaChangeAnnotation a : edits) {
-                if (OP_INSERT.equals(a.getOperation())) {
-//                    getLogger().debug("Performing insert[" + a.getBegin() + "-" + a.getEnd() + "]: ["
-//                                    + a.getCoveredText() + "]");
-                    as.insert(a.getBegin(), a.getValue());
-                }
-                if (OP_DELETE.equals(a.getOperation())) {
-//                    getLogger().debug("Performing delete[" + a.getBegin() + "-" + a.getEnd() + "]: ["
-//                            + a.getCoveredText() + "]");
-                    as.delete(a.getBegin(), a.getEnd());
-                }
-                if (OP_REPLACE.equals(a.getOperation())) {
-//                    getLogger().debug("Performing replace[" + a.getBegin() + "-" + a.getEnd() + "]: ["
-//                            + a.getCoveredText() + "]");
-                    as.replace(a.getBegin(), a.getEnd(), a.getValue());
-                }
-            }
-        }
+        AlignedString as = AlignmentBuild.from(aSourceView);
 
         // Set the text of the new Sofa
         aTargetView.setDocumentText(as.get());

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
@@ -20,7 +20,7 @@ package de.tudarmstadt.ukp.dkpro.core.castransformation;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
 import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentBuild;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentFactory;
 import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
 import eu.openminted.share.annotations.api.DocumentationResource;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
@@ -73,7 +73,7 @@ public class ApplyChangesAnnotator
 
     protected void applyChanges(JCas aSourceView, JCas aTargetView)
     {
-        AlignedString as = AlignmentBuild.from(aSourceView);
+        AlignedString as = AlignmentFactory.from(aSourceView);
 
         // Set the text of the new Sofa
         aTargetView.setDocumentText(as.get());

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesAnnotator.java
@@ -73,7 +73,7 @@ public class ApplyChangesAnnotator
 
     protected void applyChanges(JCas aSourceView, JCas aTargetView)
     {
-        AlignedString as = AlignmentFactory.from(aSourceView);
+        AlignedString as = AlignmentFactory.createAlignmentsFor(aSourceView);
 
         // Set the text of the new Sofa
         aTargetView.setDocumentText(as.get());

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
@@ -151,8 +151,8 @@ public class Backmapper
         if (as == null) {
             // Attempt to reconstruct the alignment from the SofaChangeAnnotations.
             // This only works when they have not been altered in the mean time.
-            JCas source = aSomeCase.getCas().getView(to).getJCas();
-            as = AlignmentFactory.from(source);
+            JCas view = aSomeCase.getCas().getView(to).getJCas();
+            as = AlignmentFactory.createAlignmentsFor(view);
         }
 
         // If there is none we have to fail. Practically this should never happen

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
@@ -72,8 +72,8 @@ public class Backmapper
         try {
             // Now we can copy the complete CAS while mapping back the offsets.
             // We first use the CAS copier and then update the offsets.
-            getLogger().info("Copying annotations from [" + sofaChain.getFirst() + "] to ["
-                            + sofaChain.getLast() + "]");
+            getLogger().info("Copying annotations from [" + sofaChain.getFirst() +
+                    "] to [" + sofaChain.getLast() + "]");
             
             // Copy the annotations
             CAS sourceView = aJCas.getCas().getView(sofaChain.getFirst());
@@ -124,10 +124,6 @@ public class Backmapper
                 
                 AlignedString as = getAlignedString(aJCas, realSource, realTarget);
 
-                if(as == null) {
-                    //
-                }
-                
                 updateOffsets(sourceView, targetViewJCas, as, copiedFs);
             }
             while (!workChain.isEmpty());
@@ -152,15 +148,15 @@ public class Backmapper
         AlignmentStorage asstore = AlignmentStorage.getInstance();
         AlignedString as = asstore.get(baseCas, to, from);
 
-        if(as == null) {
-            // Attempt to reconstruct the alignment from the SofaChangeAnnotations. This only works when they have not
-            // been altered in the mean time.
+        if (as == null) {
+            // Attempt to reconstruct the alignment from the SofaChangeAnnotations.
+            // This only works when they have not been altered in the mean time.
             JCas source = aSomeCase.getCas().getView(to).getJCas();
             as = AlignmentBuild.from(source);
         }
 
-        // If there is none we have to fail. Practically this should never happen when the alignment state is
-        // reconstructed in the previous step.
+        // If there is none we have to fail. Practically this should never happen
+        // when the alignment state is reconstructed in the previous step.
         if (as == null) {
             throw new AnalysisEngineProcessException(new IllegalStateException(
                     "No mapping found from [" + from + "] to [" + to + "] on ["

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
@@ -20,7 +20,7 @@ package de.tudarmstadt.ukp.dkpro.core.castransformation;
 import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
 import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.ImmutableInterval;
 import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.Interval;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentBuild;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentFactory;
 import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
 import eu.openminted.share.annotations.api.DocumentationResource;
 import org.apache.uima.UIMAException;
@@ -152,7 +152,7 @@ public class Backmapper
             // Attempt to reconstruct the alignment from the SofaChangeAnnotations.
             // This only works when they have not been altered in the mean time.
             JCas source = aSomeCase.getCas().getView(to).getJCas();
-            as = AlignmentBuild.from(source);
+            as = AlignmentFactory.from(source);
         }
 
         // If there is none we have to fail. Practically this should never happen

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/Backmapper.java
@@ -17,15 +17,17 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.castransformation;
 
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.ImmutableInterval;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.Interval;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentFactory;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
-import eu.openminted.share.annotations.api.DocumentationResource;
+import static org.apache.uima.fit.util.CasUtil.selectAllFS;
+
+import java.util.LinkedList;
+
 import org.apache.uima.UIMAException;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
-import org.apache.uima.cas.*;
+import org.apache.uima.cas.AnnotationBaseFS;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.CASException;
+import org.apache.uima.cas.Feature;
+import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.fit.component.JCasAnnotator_ImplBase;
 import org.apache.uima.fit.descriptor.ConfigurationParameter;
 import org.apache.uima.fit.descriptor.ResourceMetaData;
@@ -36,9 +38,13 @@ import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.util.CasCopier;
 
-import java.util.LinkedList;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.ImmutableInterval;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.Interval;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentFactory;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
 
-import static org.apache.uima.fit.util.CasUtil.selectAllFS;
+import eu.openminted.share.annotations.api.DocumentationResource;
 
 /**
  * After processing a file with the {@code ApplyChangesAnnotator} this annotator

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentBuild.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentBuild.java
@@ -1,0 +1,98 @@
+package de.tudarmstadt.ukp.dkpro.core.castransformation.internal;
+
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.Backmapper;
+import org.apache.uima.cas.FSIndex;
+import org.apache.uima.cas.FSIterator;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Supports building of alignment state from the {@link ApplyChangesAnnotator} to the {@link Backmapper} using
+ * {@link de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation} found in the source view. The
+ * alignment state is building during instance construction and is immutable after.
+ */
+
+public class AlignmentBuild {
+
+    private final AlignedString alignmentState;
+
+    public AlignmentBuild(JCas aSourceView) {
+        FSIndex<Annotation> idx = aSourceView.getAnnotationIndex(SofaChangeAnnotation.type);
+
+        // Apply all the changes
+        alignmentState = new AlignedString(aSourceView.getDocumentText());
+
+        // Collect all those edits that are going to be executed.
+        //
+        // | A | C1 C2 R
+        // BBBBBB + - -
+        // BBBBBBBBBB + + +
+        // BBBBBBBBBBBBBBBBB + + +
+        // BBBBBBB - + -
+        // BBBBBBBBBBBBB - + -
+        // BBBBBBBB - + -
+        //
+        if (idx.size() > 0) {
+            List<SofaChangeAnnotation> edits = new ArrayList<SofaChangeAnnotation>();
+            {
+                // Get an iterator over all the change annotations. Per UIMA default
+                // this iterator is sorted first by begin and then by end offsets.
+                // We will make use of this fact here to skip change annotations that
+                // are covered by others. The earliest longest change wins - this means
+                // the one with the smallest begin offset and the largest end offset.
+                FSIterator<Annotation> it = idx.iterator();
+
+                SofaChangeAnnotation top = (SofaChangeAnnotation) it.get();
+                edits.add(top);
+                it.moveToNext();
+                while (it.isValid()) {
+                    SofaChangeAnnotation b = (SofaChangeAnnotation) it.get();
+                    if (((top.getBegin() <= b.getBegin()) && // C1
+                            (top.getEnd() > b.getBegin()) // C2
+                            )
+                            || ((top.getBegin() == b.getBegin()) && (top.getEnd() == b.getEnd()))) {
+                        // Found annotation covering current annotation. Skipping
+                        // current annotation.
+                    }
+                    else {
+                        top = b;
+                        edits.add(top);
+                    }
+                    it.moveToNext();
+                }
+            }
+
+            // If we remove or add stuff all offsets right of the change location
+            // will change and thus the offsets in the change annotation are no
+            // longer valid. If we move from right to left it works better because
+            // the left offsets remain stable.
+            Collections.reverse(edits);
+            for (SofaChangeAnnotation a : edits) {
+                if (ApplyChangesAnnotator.OP_INSERT.equals(a.getOperation())) {
+                    alignmentState.insert(a.getBegin(), a.getValue());
+                }
+                if (ApplyChangesAnnotator.OP_DELETE.equals(a.getOperation())) {
+                    alignmentState.delete(a.getBegin(), a.getEnd());
+                }
+                if (ApplyChangesAnnotator.OP_REPLACE.equals(a.getOperation())) {
+                    alignmentState.replace(a.getBegin(), a.getEnd(), a.getValue());
+                }
+            }
+        }
+    }
+
+    public AlignedString getAlignmentState() {
+        return alignmentState;
+    }
+
+    public static AlignedString from(JCas aSourceView) {
+        return new AlignmentBuild(aSourceView).getAlignmentState();
+    }
+}

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentBuild.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentBuild.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.dkpro.core.castransformation.internal;
 
 import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
@@ -14,9 +31,12 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Supports building of alignment state from the {@link ApplyChangesAnnotator} to the {@link Backmapper} using
- * {@link de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation} found in the source view. The
- * alignment state is building during instance construction and is immutable after.
+ * Supports building of alignment state from the {@link ApplyChangesAnnotator} to the {@link
+ * Backmapper} using {@link de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation}
+ * found in the source view. The alignment state is building during instance construction and is
+ * immutable after.
+ *
+ * @since 1.9.3
  */
 
 public class AlignmentBuild {

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentBuild.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentBuild.java
@@ -41,13 +41,12 @@ import java.util.List;
 
 public class AlignmentBuild {
 
-    private final AlignedString alignmentState;
+    public static AlignedString from(JCas aSourceView) {
 
-    public AlignmentBuild(JCas aSourceView) {
         FSIndex<Annotation> idx = aSourceView.getAnnotationIndex(SofaChangeAnnotation.type);
 
         // Apply all the changes
-        alignmentState = new AlignedString(aSourceView.getDocumentText());
+        AlignedString alignmentState = new AlignedString(aSourceView.getDocumentText());
 
         // Collect all those edits that are going to be executed.
         //
@@ -106,13 +105,7 @@ public class AlignmentBuild {
                 }
             }
         }
-    }
 
-    public AlignedString getAlignmentState() {
         return alignmentState;
-    }
-
-    public static AlignedString from(JCas aSourceView) {
-        return new AlignmentBuild(aSourceView).getAlignmentState();
     }
 }

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentFactory.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentFactory.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public class AlignmentFactory {
 
-    public static AlignedString from(JCas aSourceView) {
+    public static AlignedString createAlignmentsFor(JCas aSourceView) {
 
         FSIndex<Annotation> idx = aSourceView.getAnnotationIndex(SofaChangeAnnotation.type);
 

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentFactory.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentFactory.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.castransformation.internal;
 
+import de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations;
 import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
 import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
 import de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator;
@@ -94,13 +95,13 @@ public class AlignmentFactory {
             // the left offsets remain stable.
             Collections.reverse(edits);
             for (SofaChangeAnnotation a : edits) {
-                if (ApplyChangesAnnotator.OP_INSERT.equals(a.getOperation())) {
+                if (SofaChangeOperations.OP_INSERT.equals(a.getOperation())) {
                     alignmentState.insert(a.getBegin(), a.getValue());
                 }
-                if (ApplyChangesAnnotator.OP_DELETE.equals(a.getOperation())) {
+                if (SofaChangeOperations.OP_DELETE.equals(a.getOperation())) {
                     alignmentState.delete(a.getBegin(), a.getEnd());
                 }
-                if (ApplyChangesAnnotator.OP_REPLACE.equals(a.getOperation())) {
+                if (SofaChangeOperations.OP_REPLACE.equals(a.getOperation())) {
                     alignmentState.replace(a.getBegin(), a.getEnd(), a.getValue());
                 }
             }

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentFactory.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentFactory.java
@@ -39,7 +39,7 @@ import java.util.List;
  * @since 1.9.3
  */
 
-public class AlignmentBuild {
+public class AlignmentFactory {
 
     public static AlignedString from(JCas aSourceView) {
 

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentFactory.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentFactory.java
@@ -17,25 +17,25 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.castransformation.internal;
 
-import de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator;
-import de.tudarmstadt.ukp.dkpro.core.castransformation.Backmapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.uima.cas.FSIndex;
 import org.apache.uima.cas.FSIterator;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.tcas.Annotation;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.Backmapper;
 
 /**
- * Supports building of alignment state from the {@link ApplyChangesAnnotator} to the {@link
- * Backmapper} using {@link de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation}
- * found in the source view. The alignment state is building during instance construction and is
- * immutable after.
+ * Creates alignment state for the {@link ApplyChangesAnnotator} and the {@link Backmapper} using
+ * {@link de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation} found in the view
+ * that was mapped.
  *
  * @since 1.9.3
  */

--- a/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentStorage.java
+++ b/dkpro-core-castransformation-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/castransformation/internal/AlignmentStorage.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.castransformation.internal;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -40,7 +41,9 @@ public class AlignmentStorage
     private Map<CAS, Map<Key, AlignedString>> mmap;
 
     {
-        mmap = new WeakHashMap<CAS, Map<Key, AlignedString>>();
+        // WeakHashMap is not threadsafe, so we need to wrap it, because it will likely be
+        // invoked by many concurrent pipeline threads.
+        mmap = Collections.synchronizedMap(new WeakHashMap<CAS, Map<Key, AlignedString>>());
     }
 
     public static synchronized AlignmentStorage getInstance()
@@ -62,15 +65,14 @@ public class AlignmentStorage
 
     public void put(final CAS aCas, final String from, final String to, final AlignedString aAs)
     {
-        Map<Key, AlignedString> map = mmap.get(aCas);
-        if (map == null) {
-            map = new HashMap<Key, AlignedString>();
-            mmap.put(aCas, map);
-        }
-
+        Map<Key, AlignedString> map = mmap.computeIfAbsent(aCas, k -> new HashMap<>());
+        // No reason to keep the internal map synchronized because it's specific to the CAS, and
+        // it is assumed that two different pipeline threads in any execution environment never
+        // manipulate the same CAS instance simultaneously.
         System.out.println("Adding from [" + from + "] to [" + to + "] on [" + aCas.hashCode()
                 + "]");
         map.put(new Key(from, to), aAs);
+
     }
 
     private static class Key

--- a/dkpro-core-castransformation-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesBackmapperTest.java
+++ b/dkpro-core-castransformation-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/castransformation/ApplyChangesBackmapperTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileWriter;
 
-import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
 import org.apache.commons.io.FileUtils;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
@@ -41,6 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
+import de.tudarmstadt.ukp.dkpro.core.castransformation.internal.AlignmentStorage;
 import de.tudarmstadt.ukp.dkpro.core.io.text.TextReader;
 import de.tudarmstadt.ukp.dkpro.core.io.xmi.XmiWriter;
 import de.tudarmstadt.ukp.dkpro.core.testing.DkproTestContext;
@@ -108,7 +108,7 @@ public class ApplyChangesBackmapperTest
         builder.add(applyChanges, ApplyChangesAnnotator.VIEW_TARGET, TARGET_VIEW,
                 ApplyChangesAnnotator.VIEW_SOURCE, CAS.NAME_DEFAULT_SOFA);
         builder.add(segmenter, CAS.NAME_DEFAULT_SOFA, TARGET_VIEW);
-        if(clearAlignmentState) {
+        if (clearAlignmentState) {
             builder.add(clearAlignmentCache, CAS.NAME_DEFAULT_SOFA, TARGET_VIEW);
         }
         builder.add(backMapper);
@@ -176,7 +176,7 @@ public class ApplyChangesBackmapperTest
             // the Backmapper and the alignment store involved, but it is much simpler compared
             // to building pipelines that store the CAS at the point before backmapping, and then
             // restore it to resume processing from that point with a complete process restart
-            // between store and restore, since the aligment store is a singleton that will
+            // between store and restore, since the alignment store is a singleton that will
             // otherwise persist and not be cleared.
             AlignmentStorage.getInstance().put(
                     jCas.getCasImpl().getBaseCAS(),

--- a/dkpro-core-textnormalizer-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/textnormalizer/ReplacementFileNormalizer.java
+++ b/dkpro-core-textnormalizer-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/textnormalizer/ReplacementFileNormalizer.java
@@ -17,18 +17,12 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.textnormalizer;
 
-import static de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator.OP_REPLACE;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import de.tudarmstadt.ukp.dkpro.core.api.parameter.ComponentParameters;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
+import eu.openminted.share.annotations.api.Component;
+import eu.openminted.share.annotations.api.DocumentationResource;
+import eu.openminted.share.annotations.api.constants.OperationType;
 import org.apache.commons.io.FileUtils;
 import org.apache.uima.UimaContext;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
@@ -38,12 +32,13 @@ import org.apache.uima.fit.descriptor.TypeCapability;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.ResourceInitializationException;
 
-import de.tudarmstadt.ukp.dkpro.core.api.parameter.ComponentParameters;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
-import eu.openminted.share.annotations.api.Component;
-import eu.openminted.share.annotations.api.DocumentationResource;
-import eu.openminted.share.annotations.api.constants.OperationType;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations.OP_REPLACE;
 
 /**
  * Takes a text and replaces desired expressions. This class should not work on tokens as some

--- a/dkpro-core-textnormalizer-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/textnormalizer/ReplacementFileNormalizer.java
+++ b/dkpro-core-textnormalizer-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/textnormalizer/ReplacementFileNormalizer.java
@@ -17,12 +17,18 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.textnormalizer;
 
-import de.tudarmstadt.ukp.dkpro.core.api.parameter.ComponentParameters;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
-import eu.openminted.share.annotations.api.Component;
-import eu.openminted.share.annotations.api.DocumentationResource;
-import eu.openminted.share.annotations.api.constants.OperationType;
+import static de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations.OP_REPLACE;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.uima.UimaContext;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
@@ -32,13 +38,13 @@ import org.apache.uima.fit.descriptor.TypeCapability;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.ResourceInitializationException;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import de.tudarmstadt.ukp.dkpro.core.api.parameter.ComponentParameters;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
 
-import static de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations.OP_REPLACE;
+import eu.openminted.share.annotations.api.Component;
+import eu.openminted.share.annotations.api.DocumentationResource;
+import eu.openminted.share.annotations.api.constants.OperationType;
 
 /**
  * Takes a text and replaces desired expressions. This class should not work on tokens as some

--- a/dkpro-core-textnormalizer-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/textnormalizer/util/NormalizationUtils.java
+++ b/dkpro-core-textnormalizer-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/textnormalizer/util/NormalizationUtils.java
@@ -17,13 +17,15 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.textnormalizer.util;
 
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
+import static de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations.OP_DELETE;
+import static de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations.OP_INSERT;
+import static de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations.OP_REPLACE;
 
 import java.util.Collections;
 import java.util.List;
 
-import static de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations.*;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
 
 public class NormalizationUtils {
 

--- a/dkpro-core-textnormalizer-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/textnormalizer/util/NormalizationUtils.java
+++ b/dkpro-core-textnormalizer-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/textnormalizer/util/NormalizationUtils.java
@@ -17,15 +17,13 @@
  */
 package de.tudarmstadt.ukp.dkpro.core.textnormalizer.util;
 
-import static de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator.OP_DELETE;
-import static de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator.OP_INSERT;
-import static de.tudarmstadt.ukp.dkpro.core.castransformation.ApplyChangesAnnotator.OP_REPLACE;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
+import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
 
 import java.util.Collections;
 import java.util.List;
 
-import de.tudarmstadt.ukp.dkpro.core.api.transform.alignment.AlignedString;
-import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
+import static de.tudarmstadt.ukp.dkpro.core.api.transform.SofaChangeOperations.*;
 
 public class NormalizationUtils {
 


### PR DESCRIPTION
This is a draft PR that addresses issue 1244. Additionally minor refactorings were done to clean up the code a bit, e.g the SofaChangeAnnotation operation constants were moved out of the ApplyChangesAnnotator and into a separate SofaChangeOperations class in the transformation package where the SofaChangeAnnotation is also found. There were more dependencies to those constants, and it seemed odd if lower level classes had to depend on integrating components like the AE. The location probably needs to be discussed before merging.

I also fixed what I considered to be a concurrency bug in the AlignmentStore, although I practically never observed irregularities with it. It could just be a rare occurrence since the internal map never changes after initializations due to CAS recycling in our case.
