### PR TITLE
Feature/1247 brat multiline handling

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -43,6 +43,7 @@ Mateusz Parzonka
 Michael Unterkalmsteiner [mikmakmuk]
 Milen Kouylekov <milen.kouylekov@usit.uio.no> [kouylekov, kouylekov-usit]
 Nicolai Erbs <nico.erbs@gmail.com> [nicolaierbs]
+Nicolas Paris [parisni]
 Niklas Jakob 
 Nils Reimers [nreimers]
 Oliver Ferschke [ferschke]

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReader.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReader.java
@@ -230,37 +230,40 @@ public class BratReader
     private void create(CAS aCAS, Type aType, BratTextAnnotation aAnno)
     {
         TextAnnotationParam param = parsedTextAnnotationTypes.get(aType.getName());
-        
-        AnnotationFS anno = aCAS.createAnnotation(aType, aAnno.getBegin(), aAnno.getEnd());
-        
-        fillAttributes(anno, aAnno.getAttributes());
-        
-        if (param != null && param.getSubcat() != null) {
-            anno.setStringValue(getFeature(anno, param.getSubcat()), aAnno.getType());
+        for (int i = 0; i < aAnno.getBegin().length; i++) {
+            AnnotationFS anno = aCAS.createAnnotation(aType, aAnno.getBegin()[i],
+                    aAnno.getEnd()[i]);
+            fillAttributes(anno, aAnno.getAttributes());
+
+            if (param != null && param.getSubcat() != null) {
+                anno.setStringValue(getFeature(anno, param.getSubcat()), aAnno.getType());
+            }
+
+            aCAS.addFsToIndexes(anno);
+            spanIdMap.put(aAnno.getId(), anno);
         }
-        
-        aCAS.addFsToIndexes(anno);
-        spanIdMap.put(aAnno.getId(), anno);
     }
 
     private void create(CAS aCAS, Type aType, BratEventAnnotation aAnno)
     {
         TextAnnotationParam param = parsedTextAnnotationTypes.get(aType.getName());
-        
-        AnnotationFS anno = aCAS.createAnnotation(aType, 
-                aAnno.getTriggerAnnotation().getBegin(), aAnno.getTriggerAnnotation().getEnd());
+        for (int i = 0; i < aAnno.getTriggerAnnotation().getBegin().length; i++) {
+            AnnotationFS anno = aCAS.createAnnotation(aType,
+                    aAnno.getTriggerAnnotation().getBegin()[i],
+                    aAnno.getTriggerAnnotation().getEnd()[i]);
 
-        fillAttributes(anno, aAnno.getAttributes());
+            fillAttributes(anno, aAnno.getAttributes());
 
-        if (param != null && param.getSubcat() != null) {
-            anno.setStringValue(getFeature(anno, param.getSubcat()), aAnno.getType());
+            if (param != null && param.getSubcat() != null) {
+                anno.setStringValue(getFeature(anno, param.getSubcat()), aAnno.getType());
+            }
+
+            // Slots cannot be handled yet because they might point to events that have not been
+            // created yet.
+
+            aCAS.addFsToIndexes(anno);
+            spanIdMap.put(aAnno.getId(), anno);
         }
-        
-        // Slots cannot be handled yet because they might point to events that have not been 
-        // created yet.
-        
-        aCAS.addFsToIndexes(anno);
-        spanIdMap.put(aAnno.getId(), anno);
     }
     
     private void create(CAS aCAS, Type aType, BratRelationAnnotation aAnno)

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
@@ -617,24 +617,25 @@ public class BratWriter extends JCasFileWriter_ImplBase
 
     private BratTextAnnotation splitNewline(AnnotationFS aFS)
     {
-        String newlineString = "i";;
-        String[] textSplit = aFS.getCoveredText().split(newlineString);
+        String[] textSplit = explodeNewlines(aFS.getCoveredText());
         int[] begins = new int[textSplit.length];
         int[] ends = new int[textSplit.length];
-        int pos = 0;
-        int end = 0;
+        int pos = aFS.getBegin();
+        int end = aFS.getBegin();
         for (int i = 0; i < textSplit.length; i++) {
-            System.out.println("tto"+i);
             end += textSplit[i].length();
-            if (end != pos) {// case of empty lines
-                begins[i] = pos;
-                ends[i] = end;
-                pos = end + 1;
-            }
+            begins[i] = pos;
+            ends[i] = end;
+            end++;
+            pos = end;
         }
 
         return new BratTextAnnotation(nextTextAnnotationId, getBratType(aFS.getType()), begins,
-                ends, new String[] { aFS.getCoveredText() });
+                ends, new String[] { aFS.getCoveredText().replaceAll("\\R", " ") });
+    }
+    
+    private String[] explodeNewlines(String str) {
+        return str.split("\\R");
     }
     
     private void writeTextAnnotation(BratAnnotationDocument aDoc, AnnotationFS aFS)

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
@@ -633,7 +633,6 @@ public class BratWriter extends JCasFileWriter_ImplBase
         m = p.matcher(aFS.getCoveredText());
         i = 0;
         while (m.find()) {
-            System.out.println(m.group(1));
             begins[i] = m.start(1) + aFS.getBegin();
             ends[i] = m.end(1) + aFS.getBegin();
             i++;

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
@@ -615,27 +615,32 @@ public class BratWriter extends JCasFileWriter_ImplBase
         }
     }
 
+
+    
     private BratTextAnnotation splitNewline(AnnotationFS aFS)
     {
-        String[] textSplit = explodeNewlines(aFS.getCoveredText());
-        int[] begins = new int[textSplit.length];
-        int[] ends = new int[textSplit.length];
-        int pos = aFS.getBegin();
-        int end = aFS.getBegin();
-        for (int i = 0; i < textSplit.length; i++) {
-            end += textSplit[i].length();
-            begins[i] = pos;
-            ends[i] = end;
-            end++;
-            pos = end;
+
+        Pattern p = Pattern.compile("(.+?)(?:\\R|$)+", Pattern.DOTALL);
+        Matcher m = p.matcher(aFS.getCoveredText());
+        // counts the number of matches to initialize arrays sized
+        int i = 0;
+        while (m.find()) {
+            i++;
+        }
+        // initialize arrays
+        int[] begins = new int[i];
+        int[] ends = new int[i];
+        m = p.matcher(aFS.getCoveredText());
+        i = 0;
+        while (m.find()) {
+            System.out.println(m.group(1));
+            begins[i] = m.start(1) + aFS.getBegin();
+            ends[i] = m.end(1) + aFS.getBegin();
+            i++;
         }
 
         return new BratTextAnnotation(nextTextAnnotationId, getBratType(aFS.getType()), begins,
-                ends, new String[] { aFS.getCoveredText().replaceAll("\\R", " ") });
-    }
-    
-    private String[] explodeNewlines(String str) {
-        return str.split("\\R");
+                ends, new String[] { aFS.getCoveredText().replaceAll("\\R+", " ") });
     }
     
     private void writeTextAnnotation(BratAnnotationDocument aDoc, AnnotationFS aFS)

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratWriter.java
@@ -436,9 +436,10 @@ public class BratWriter extends JCasFileWriter_ImplBase
     
     private BratEventAnnotation writeEventAnnotation(BratAnnotationDocument aDoc, AnnotationFS aFS)
     {
+
         // Write trigger annotation
         BratTextAnnotation trigger = new BratTextAnnotation(nextTextAnnotationId, 
-                getBratType(aFS.getType()), aFS.getBegin(), aFS.getEnd(), aFS.getCoveredText());
+                getBratType(aFS.getType()), new int[] {aFS.getBegin()}, new int[] {aFS.getEnd()}, new String[] {aFS.getCoveredText()});
         nextTextAnnotationId++;
         
         // Write event annotation
@@ -616,7 +617,7 @@ public class BratWriter extends JCasFileWriter_ImplBase
         String type = getBratType(aFS.getType());
         
         BratTextAnnotation anno = new BratTextAnnotation(nextTextAnnotationId, type,
-                aFS.getBegin(), aFS.getEnd(), aFS.getCoveredText());
+                new int[] {aFS.getBegin()}, new int[] {aFS.getEnd()}, new String[] {aFS.getCoveredText()});
         nextTextAnnotationId++;
 
         conf.addEntityDecl(superType, type);

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratAnnotationDocument.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratAnnotationDocument.java
@@ -35,13 +35,13 @@ public class BratAnnotationDocument
 {
     private Map<String, BratAnnotation> annotations = new LinkedHashMap<>();
     private Map<String, BratAttribute> attributes = new LinkedHashMap<>();
-
+    
     public static BratAnnotationDocument read(Reader aReader)
     {
         BratAnnotationDocument doc = new BratAnnotationDocument();
-
+        
         List<BratEventAnnotation> events = new ArrayList<>();
-
+        
         // Read from file
         LineIterator lines = IOUtils.lineIterator(aReader);
         while (lines.hasNext()) {
@@ -74,46 +74,47 @@ public class BratAnnotationDocument
         // Attach attributes to annotations
         for (BratAttribute attr : doc.attributes.values()) {
             BratAnnotation target = doc.annotations.get(attr.getTarget());
-
+            
             if (target == null) {
-                throw new IllegalStateException(
-                        "Attribute refers to unknown annotation [" + attr.getTarget() + "]");
+                throw new IllegalStateException("Attribute refers to unknown annotation ["
+                        + attr.getTarget() + "]");
             }
-
+            
             target.addAttribute(attr);
         }
 
         // FIXME this is currently inconsistent between reading and manual creation / writing
         // when we read the triggers, they no longer appear as individual annotations
         // when we manually create the brat annotations, we leave the triggers
-
+        
         // Attach triggers to events and remove them as individual annotations
         List<String> triggersIds = new ArrayList<>();
         for (BratEventAnnotation event : events) {
-            BratTextAnnotation trigger = (BratTextAnnotation) doc.annotations
-                    .get(event.getTrigger());
+            BratTextAnnotation trigger = (BratTextAnnotation) doc.annotations.get(event
+                    .getTrigger());
 
             if (trigger == null) {
-                throw new IllegalStateException(
-                        "Trigger refers to unknown annotation [" + event.getTrigger() + "]");
+                throw new IllegalStateException("Trigger refers to unknown annotation ["
+                        + event.getTrigger() + "]");
             }
-
+            
             triggersIds.add(trigger.getId());
             event.setTriggerAnnotation(trigger);
         }
-
+        
         // Remove trigger annotations, they are owned by the event
         doc.annotations.keySet().removeAll(triggersIds);
-
+        
         return doc;
     }
-
-    public void write(JsonGenerator aJG, String aText) throws IOException
+    
+    public void write(JsonGenerator aJG, String aText) 
+        throws IOException
     {
         aJG.writeStartObject();
 
         aJG.writeStringField("text", aText);
-
+        
         aJG.writeFieldName("entities");
         aJG.writeStartArray();
         for (BratAnnotation ann : annotations.values()) {
@@ -140,7 +141,7 @@ public class BratAnnotationDocument
             }
         }
         aJG.writeEndArray();
-
+        
         aJG.writeFieldName("events");
         aJG.writeStartArray();
         for (BratAnnotation ann : annotations.values()) {
@@ -161,22 +162,23 @@ public class BratAnnotationDocument
 
         aJG.writeEndObject();
     }
-
-    public void write(Writer aWriter) throws IOException
+    
+    public void write(Writer aWriter)
+        throws IOException
     {
         // First render only the spans because brat wants to now them first for their IDs
         for (BratAnnotation anno : annotations.values()) {
             if (anno instanceof BratTextAnnotation) {
                 write(aWriter, anno);
             }
-
+            
             if (anno instanceof BratEventAnnotation) {
                 // Just write the trigger for now
                 BratEventAnnotation event = (BratEventAnnotation) anno;
                 write(aWriter, event.getTriggerAnnotation());
             }
         }
-
+        
         // Second render all annotations that point to span annotations
         for (BratAnnotation anno : annotations.values()) {
             // Skip the text annotations, we already rendered them in the first pass
@@ -187,8 +189,9 @@ public class BratAnnotationDocument
             write(aWriter, anno);
         }
     }
-
-    private void write(Writer aWriter, BratAnnotation aAnno) throws IOException
+    
+    private void write(Writer aWriter, BratAnnotation aAnno)
+        throws IOException
     {
         aWriter.append(aAnno.toString());
         aWriter.append('\n');
@@ -197,28 +200,22 @@ public class BratAnnotationDocument
             aWriter.append('\n');
         }
     }
-
+    
     public void addAttribute(BratAttribute aAttribute)
     {
         attributes.put(aAttribute.getId(), aAttribute);
     }
-
+    
     public void addAnnotation(BratAnnotation aAnnotation)
     {
         annotations.put(aAnnotation.getId(), aAnnotation);
     }
-
-    public void addAnnotation(BratAnnotation[] aAnnotations)
-    {
-        for (BratAnnotation aAnnotation : aAnnotations)
-            annotations.put(aAnnotation.getId(), aAnnotation);
-    }
-
+    
     public BratAnnotation getAnnotation(String aId)
     {
         return annotations.get(aId);
     }
-
+    
     public Collection<BratAnnotation> getAnnotations()
     {
         return annotations.values();

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
@@ -55,16 +55,15 @@ public class BratTextAnnotation
         end = aEnd;
         text = aText;
     }
-    
-    public BratTextAnnotation(String aId, String aType, String aBegin, String aText)
+
+    public BratTextAnnotation(String aId, String aType, String aOffset, String aText)
     {
         super(aId, aType);
-        ArrayList<int[]> beginEnd = getBeginAndEnd(aBegin);
-        begin = beginEnd.get(0);
-        end = beginEnd.get(1);
+        BratTextOffset bratTextOffset = new BratTextOffset(aOffset);
+        begin = bratTextOffset.getBegin();
+        end = bratTextOffset.getEnd();
         text = splitText(aText, begin, end);
-        
-    }
+     }
     
     
     private String[] splitText(String aText, int[] aBegin, int[] aEnd)
@@ -112,7 +111,7 @@ public class BratTextAnnotation
     @Override
     public String toString()
     {
-        return getId() + '\t' + getType() + generateOffset(begin, end) + '\t' + String.join(" ", text);
+        return getId() + '\t' + getType() + ' ' + generateOffset(begin, end) + '\t' + String.join(" ", text);
     }
     
     private String generateOffset(int[] begin, int[] end)
@@ -120,30 +119,12 @@ public class BratTextAnnotation
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < begin.length; i++) {
             sb.append(String.format("%s %s", begin[i], end[i]));
-            if (i < begin.length && begin.length > 1) {
-                sb.append(";");
-            }
-        }
-        return sb.toString();
-    }
-    
-    private ArrayList<int[]> getBeginAndEnd(String offset)
-    {
-        ArrayList<int[]> result = new ArrayList<int[]>();
+            sb.append(";");
 
-        String[] offsets = offset.split(";");
-        int[] begins = new int[offsets.length];
-        int[] ends = new int[offsets.length];
-        for (int i = 0; i < offsets.length; i++) {
-            String[] beginEnd = offsets[i].split(" ");
-            begins[i] = Integer.parseInt(beginEnd[0]);
-            ends[i] = Integer.parseInt(beginEnd[1]);
         }
-        result.add(begins);
-        result.add(ends);
-
-        return result;
+        return sb.toString().replaceFirst(";$", "");
     }
+
 
     public static BratTextAnnotation parse(String aLine)
     {

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.dkpro.core.io.brat.internal.model;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -98,15 +99,16 @@ public class BratTextAnnotation
         return getId() + '\t' + getType() + ' ' + begin + ' ' + end + '\t' + text;
     }
 
-    public static BratTextAnnotation parse(String aLine)
+    public static BratTextAnnotation[] parse(String aLine)
     {
+        ArrayList<BratTextAnnotation> discontinuousAnn = new ArrayList<BratTextAnnotation>();
         Matcher m = PATTERN.matcher(aLine);
-        
+
         if (!m.matches()) {
             throw new IllegalArgumentException("Illegal text annotation format [" + aLine + "]");
         }
-
-        return new BratTextAnnotation(m.group(ID), m.group(TYPE), Integer.valueOf(m.group(BEGIN)),
-                Integer.valueOf(m.group(END)), m.group(TEXT));
+        discontinuousAnn.add(new BratTextAnnotation(m.group(ID), m.group(TYPE),
+                Integer.valueOf(m.group(BEGIN)), Integer.valueOf(m.group(END)), m.group(TEXT)));
+        return discontinuousAnn.toArray(new BratTextAnnotation[discontinuousAnn.size()]);
     }
 }

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
@@ -67,12 +67,11 @@ public class BratTextAnnotation
     private String[] splitText(String aText, int[] aBegin, int[] aEnd)
     {
         String[] result = new String[aBegin.length];
-        int normalization = aBegin[0];
+        String pieceOfText = aText;
         for (int i = 0; i < aBegin.length; i++) {
-            int beginOffset = aBegin[i] - normalization;
-            int endOffset = aEnd[i] - normalization;
-            result[i] = aText.substring(beginOffset, endOffset);
-            System.out.println(result[i]);
+            int size = aEnd[i] - aBegin[i];
+            result[i] = aText.substring(0, size);
+            pieceOfText = pieceOfText.substring(size);
         }
         return result;
     }

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.dkpro.core.io.brat.internal.model;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -99,16 +98,15 @@ public class BratTextAnnotation
         return getId() + '\t' + getType() + ' ' + begin + ' ' + end + '\t' + text;
     }
 
-    public static BratTextAnnotation[] parse(String aLine)
+    public static BratTextAnnotation parse(String aLine)
     {
-        ArrayList<BratTextAnnotation> discontinuousAnn = new ArrayList<BratTextAnnotation>();
         Matcher m = PATTERN.matcher(aLine);
-
+        
         if (!m.matches()) {
             throw new IllegalArgumentException("Illegal text annotation format [" + aLine + "]");
         }
-        discontinuousAnn.add(new BratTextAnnotation(m.group(ID), m.group(TYPE),
-                Integer.valueOf(m.group(BEGIN)), Integer.valueOf(m.group(END)), m.group(TEXT)));
-        return discontinuousAnn.toArray(new BratTextAnnotation[discontinuousAnn.size()]);
+
+        return new BratTextAnnotation(m.group(ID), m.group(TYPE), Integer.valueOf(m.group(BEGIN)),
+                Integer.valueOf(m.group(END)), m.group(TEXT));
     }
 }

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotation.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.dkpro.core.io.brat.internal.model;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -64,12 +63,18 @@ public class BratTextAnnotation
         end = bratTextOffset.getEnd();
         text = splitText(aText, begin, end);
      }
-    
-    
+      
     private String[] splitText(String aText, int[] aBegin, int[] aEnd)
     {
-        // TODO Auto-generated method stub
-        return null;
+        String[] result = new String[aBegin.length];
+        int normalization = aBegin[0];
+        for (int i = 0; i < aBegin.length; i++) {
+            int beginOffset = aBegin[i] - normalization;
+            int endOffset = aEnd[i] - normalization;
+            result[i] = aText.substring(beginOffset, endOffset);
+            System.out.println(result[i]);
+        }
+        return result;
     }
 
     public int[] getBegin()
@@ -88,26 +93,27 @@ public class BratTextAnnotation
     }
     
     @Override
-    public void write(JsonGenerator aJG)
-        throws IOException
+    public void write(JsonGenerator aJG) throws IOException
     {
         // Format: [${ID}, ${TYPE}, [[${START}, ${END}]]]
         // note that range of the offsets are [${START},${END})
         // ['T1', 'Person', [[0, 11]]]
-        
+
         aJG.writeStartArray();
         aJG.writeString(getId());
         aJG.writeString(getType());
         aJG.writeStartArray();
-        aJG.writeStartArray();
-        // TODO: add exact begin/end informations
-     //   aJG.writeNumber(begin);
-      //  aJG.writeNumber(end);
-        aJG.writeEndArray();
+        for (int i = 0; i < begin.length; i++) {
+            // handle discontinuous annotations
+            aJG.writeStartArray();
+            aJG.writeNumber(begin[i]);
+            aJG.writeNumber(end[i]);
+            aJG.writeEndArray();
+        }
         aJG.writeEndArray();
         aJG.writeEndArray();
     }
-    
+
     @Override
     public String toString()
     {

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextOffset.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextOffset.java
@@ -63,7 +63,7 @@ public class BratTextOffset
             }
             else {
                 // in case discontinous annotation
-                // 1 2;4 5 ->1 2 and 4 5
+                // 1 2;4 5 -> 1 2 and 4 5
                 begin.add(effectiveBegin);
                 end.add(effectiveEnd);
             }

--- a/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextOffset.java
+++ b/dkpro-core-io-brat-asl/src/main/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextOffset.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.dkpro.core.io.brat.internal.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class BratTextOffset
+{
+
+    private  ArrayList<Integer> begin = new ArrayList<Integer>();
+    private  ArrayList<Integer> end = new ArrayList<Integer>();
+
+    public BratTextOffset(
+            String aOffset)
+    {
+        setBeginAndEnd(aOffset);
+    }
+
+
+    public int[] getBegin()
+    {
+        return toIntArray(begin);
+    }
+
+    public int[] getEnd()
+    {
+        return toIntArray(end);
+    }
+    
+    private int[] toIntArray(ArrayList<Integer> array) {
+        return Arrays.stream(array.toArray(new Integer[array.size()])).mapToInt(Integer::intValue).toArray();
+    }
+
+
+    private void setBeginAndEnd(String offset)
+    {
+        String[] offsets = offset.split(";");
+
+        for (int i = 0; i < offsets.length; i++) {
+            String[] beginEnd = offsets[i].split(" ");
+            int effectiveBegin = Integer.parseInt(beginEnd[0]);
+            int effectiveEnd = Integer.parseInt(beginEnd[1]);
+            // in case discontinous annotation
+            // 1 2;3 4 -> 1 4
+            if (i > 0 && effectiveBegin <= (1 + end.get(end.size() - 1))) {
+                end.set(i - 1, effectiveEnd);
+            }
+            else {
+                // in case discontinous annotation
+                // 1 2;4 5 ->1 2 and 4 5
+                begin.add(effectiveBegin);
+                end.add(effectiveEnd);
+            }
+        }
+    }
+}

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
@@ -143,7 +143,21 @@ public class BratReaderWriterTest
                         true),
                 "brat/document0c.ann");
     }
-
+    
+    @Test
+    public void testBratWithDiscontinousTwo() throws Exception
+    {
+        testOneWay(createReaderDescription(BratReader.class,
+                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
+                asList("Token -> de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
+                        "Location -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location")),
+                createEngineDescription(BratWriter.class, BratWriter.PARAM_ENABLE_TYPE_MAPPINGS,
+                        true),
+                "brat/document0d-ref.ann",
+                "brat/document0d.ann");
+    }
+    
     @Test
     public void test1() throws Exception
     {

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
@@ -132,7 +132,7 @@ public class BratReaderWriterTest
     }
 
     @Test
-    public void testBratWithNewlines() throws Exception
+    public void testBratWithDiscontinuousFragmentNear() throws Exception
     {
         testRoundTrip(createReaderDescription(BratReader.class,
                 BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
@@ -145,7 +145,7 @@ public class BratReaderWriterTest
     }
     
     @Test
-    public void testBratWithDiscontinousTwo() throws Exception
+    public void testBratWithDiscontinuousFragmentFar() throws Exception
     {
         testOneWay(createReaderDescription(BratReader.class,
                 BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
@@ -36,116 +36,168 @@ import de.tudarmstadt.ukp.dkpro.core.testing.DkproTestContext;
 public class BratReaderWriterTest
 {
     @Test
-    public void testConll2009() throws Exception
+    public void testConll2009()
+        throws Exception
     {
-        // tag::testOneWay[]
-        testOneWay(createReaderDescription(Conll2009Reader.class), // the reader
+// tag::testOneWay[]
+        testOneWay(
+                createReaderDescription(Conll2009Reader.class), // the reader
                 createEngineDescription(BratWriter.class, // the writer
                         BratWriter.PARAM_WRITE_RELATION_ATTRIBUTES, true),
                 "conll/2009/en-ref.ann", // the reference file for the output
                 "conll/2009/en-orig.conll"); // the input file for the test
-        // end::testOneWay[]
+// end::testOneWay[]
     }
 
     @Test
-    public void testConll2009_2() throws Exception
+    public void testConll2009_2()
+        throws Exception
     {
-        testRoundTrip(createReaderDescription(BratReader.class),
-                createEngineDescription(BratWriter.class,
+        testRoundTrip(
+                createReaderDescription(BratReader.class), 
+                createEngineDescription(BratWriter.class, 
                         BratWriter.PARAM_WRITE_RELATION_ATTRIBUTES, true),
                 "conll/2009/en-ref.ann");
     }
 
     @Test
-    public void testConll2012Html() throws Exception
+    public void testConll2012Html()
+        throws Exception
     {
         testOneWay(
                 createReaderDescription(Conll2012Reader.class,
-                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false),
-                createEngineDescription(BratWriter.class, BratWriter.PARAM_FILENAME_EXTENSION,
-                        ".html"),
-                "conll/2012/en-ref.html", "conll/2012/en-orig.conll");
+                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false), 
+                createEngineDescription(BratWriter.class,
+                        BratWriter.PARAM_FILENAME_EXTENSION, ".html"), 
+                "conll/2012/en-ref.html",
+                "conll/2012/en-orig.conll");
     }
 
     @Test
-    public void testConll2012Json() throws Exception
+    public void testConll2012Json()
+        throws Exception
     {
         testOneWay(
                 createReaderDescription(Conll2012Reader.class,
-                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false),
-                createEngineDescription(BratWriter.class, BratWriter.PARAM_FILENAME_EXTENSION,
-                        ".json"),
-                "conll/2012/en-ref.json", "conll/2012/en-orig.conll");
+                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false), 
+                createEngineDescription(BratWriter.class,
+                        BratWriter.PARAM_FILENAME_EXTENSION, ".json"), 
+                "conll/2012/en-ref.json",
+                "conll/2012/en-orig.conll");
     }
 
     @Test
-    public void testConll2012() throws Exception
+    public void testConll2012()
+        throws Exception
     {
         testOneWay(
                 createReaderDescription(Conll2012Reader.class,
-                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false),
-                createEngineDescription(BratWriter.class), "conll/2012/en-ref.ann",
+                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false), 
+                createEngineDescription(BratWriter.class), 
+                "conll/2012/en-ref.ann",
                 "conll/2012/en-orig.conll");
     }
 
     @Ignore("Test largely ok but due to same spans for constituents not stable, thus ignoring")
     @Test
-    public void testConll2012_2() throws Exception
+    public void testConll2012_2()
+        throws Exception
     {
-        testRoundTrip(createReaderDescription(BratReader.class),
-                createEngineDescription(BratWriter.class), "conll/2012/en-ref.ann");
+        testRoundTrip(
+                createReaderDescription(BratReader.class), 
+                createEngineDescription(BratWriter.class), 
+                "conll/2012/en-ref.ann");
     }
 
     @Test
-    public void testConll2012_3() throws Exception
+    public void testConll2012_3()
+        throws Exception
     {
         testOneWay(
-                createReaderDescription(Conll2012Reader.class, Conll2012Reader.PARAM_READ_LEMMA,
-                        false, Conll2012Reader.PARAM_READ_NAMED_ENTITY, false,
+                createReaderDescription(Conll2012Reader.class,
+                        Conll2012Reader.PARAM_READ_LEMMA, false,
+                        Conll2012Reader.PARAM_READ_NAMED_ENTITY, false,
                         Conll2012Reader.PARAM_READ_SEMANTIC_PREDICATE, false,
-                        Conll2012Reader.PARAM_READ_COREFERENCE, false,
-                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false),
-                createEngineDescription(BratWriter.class), "conll/2012/en-ref-min.ann",
+                        Conll2012Reader.PARAM_READ_COREFERENCE, false, 
+                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false), 
+                createEngineDescription(BratWriter.class), 
+                "conll/2012/en-ref-min.ann",
                 "conll/2012/en-orig.conll");
     }
 
     @Test
-    public void testWithShortNames() throws Exception
+    public void testWithShortNames()
+        throws Exception
     {
-        testRoundTrip(createReaderDescription(BratReader.class,
-                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
-                asList("Token -> de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
-                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
-                        "Location -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location")),
-                createEngineDescription(BratWriter.class, BratWriter.PARAM_ENABLE_TYPE_MAPPINGS,
-                        true),
+        testRoundTrip(
+                createReaderDescription(BratReader.class,
+                        BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS, asList(
+                                "Token -> de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+                                "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
+                                "Location -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location")),
+                createEngineDescription(BratWriter.class,
+                        BratWriter.PARAM_ENABLE_TYPE_MAPPINGS, true), 
                 "brat/document0a.ann");
     }
 
     @Test
-    public void testWithLongNames() throws Exception
+    public void testWithLongNames()
+        throws Exception
     {
-        testRoundTrip(createReaderDescription(BratReader.class),
-                createEngineDescription(BratWriter.class, BratWriter.PARAM_ENABLE_TYPE_MAPPINGS,
-                        false),
+        testRoundTrip(
+                createReaderDescription(BratReader.class), 
+                createEngineDescription(BratWriter.class,
+                        BratWriter.PARAM_ENABLE_TYPE_MAPPINGS, false), 
                 "brat/document0b.ann");
     }
 
     @Test
-    public void testBratWithDiscontinuousFragmentNear() throws Exception
+    public void test1()
+        throws Exception
     {
-        testRoundTrip(createReaderDescription(BratReader.class,
-                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
-                asList("Token -> de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
-                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
-                        "Location -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location")),
-                createEngineDescription(BratWriter.class, BratWriter.PARAM_ENABLE_TYPE_MAPPINGS,
-                        true),
-                "brat/document0c.ann");
+        testOneWay(
+                createReaderDescription(BratReader.class,
+                        BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS, asList(
+                                "Country -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location",
+                                "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
+                                "MERGE-ORG -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.MergeOrg"),
+                        BratReader.PARAM_RELATION_TYPE_MAPPINGS, asList(
+                                "Origin -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation"),
+                        BratReader.PARAM_RELATION_TYPES, asList(
+                                "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
+                createEngineDescription(BratWriter.class,
+                        BratWriter.PARAM_RELATION_TYPES, asList(
+                                "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
+                "brat/document1-ref.ann", 
+                "brat/document1.ann");
+    }
+
+    @Test
+    public void testTextAnnotationWithSubcategorization()
+        throws Exception
+    {
+        testOneWay(
+                createReaderDescription(BratReader.class,
+                        BratReader.PARAM_TEXT_ANNOTATION_TYPES, 
+                                "de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity:value",
+                        BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS, asList(
+                                "Country -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
+                                "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
+                                "MERGE-ORG -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.MergeOrg"),
+                        BratReader.PARAM_RELATION_TYPE_MAPPINGS, asList(
+                                "Origin -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation"),
+                        BratReader.PARAM_RELATION_TYPES, asList(
+                                "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
+                createEngineDescription(BratWriter.class,
+                        BratWriter.PARAM_RELATION_TYPES, asList(
+                                "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
+                "brat/document1-ref-sub.ann", 
+                "brat/document1.ann");
     }
     
     @Test
-    public void testBratWithDiscontinuousFragmentFar() throws Exception
+    public void testBratWithDiscontinuousFragmentFar() 
+        throws Exception
     {
         testOneWay(createReaderDescription(BratReader.class,
                 BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
@@ -156,41 +208,6 @@ public class BratReaderWriterTest
                         true),
                 "brat/document0d-ref.ann",
                 "brat/document0d.ann");
-    }
-    
-    @Test
-    public void test1() throws Exception
-    {
-        testOneWay(createReaderDescription(BratReader.class,
-                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
-                asList("Country -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location",
-                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
-                        "MERGE-ORG -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.MergeOrg"),
-                BratReader.PARAM_RELATION_TYPE_MAPPINGS,
-                asList("Origin -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation"),
-                BratReader.PARAM_RELATION_TYPES,
-                asList("de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
-                createEngineDescription(BratWriter.class, BratWriter.PARAM_RELATION_TYPES, asList(
-                        "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
-                "brat/document1-ref.ann", "brat/document1.ann");
-    }
-
-    @Test
-    public void testTextAnnotationWithSubcategorization() throws Exception
-    {
-        testOneWay(createReaderDescription(BratReader.class, BratReader.PARAM_TEXT_ANNOTATION_TYPES,
-                "de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity:value",
-                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
-                asList("Country -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
-                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
-                        "MERGE-ORG -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.MergeOrg"),
-                BratReader.PARAM_RELATION_TYPE_MAPPINGS,
-                asList("Origin -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation"),
-                BratReader.PARAM_RELATION_TYPES,
-                asList("de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
-                createEngineDescription(BratWriter.class, BratWriter.PARAM_RELATION_TYPES, asList(
-                        "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
-                "brat/document1-ref-sub.ann", "brat/document1.ann");
     }
 
     @Rule

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
@@ -140,7 +140,7 @@ public class BratReaderWriterTest
                         "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
                         "Location -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location")),
                 createEngineDescription(BratWriter.class, BratWriter.PARAM_ENABLE_TYPE_MAPPINGS,
-                        false),
+                        true),
                 "brat/document0c.ann");
     }
 

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/BratReaderWriterTest.java
@@ -36,163 +36,147 @@ import de.tudarmstadt.ukp.dkpro.core.testing.DkproTestContext;
 public class BratReaderWriterTest
 {
     @Test
-    public void testConll2009()
-        throws Exception
+    public void testConll2009() throws Exception
     {
-// tag::testOneWay[]
-        testOneWay(
-                createReaderDescription(Conll2009Reader.class), // the reader
+        // tag::testOneWay[]
+        testOneWay(createReaderDescription(Conll2009Reader.class), // the reader
                 createEngineDescription(BratWriter.class, // the writer
                         BratWriter.PARAM_WRITE_RELATION_ATTRIBUTES, true),
                 "conll/2009/en-ref.ann", // the reference file for the output
                 "conll/2009/en-orig.conll"); // the input file for the test
-// end::testOneWay[]
+        // end::testOneWay[]
     }
 
     @Test
-    public void testConll2009_2()
-        throws Exception
+    public void testConll2009_2() throws Exception
     {
-        testRoundTrip(
-                createReaderDescription(BratReader.class), 
-                createEngineDescription(BratWriter.class, 
+        testRoundTrip(createReaderDescription(BratReader.class),
+                createEngineDescription(BratWriter.class,
                         BratWriter.PARAM_WRITE_RELATION_ATTRIBUTES, true),
                 "conll/2009/en-ref.ann");
     }
 
     @Test
-    public void testConll2012Html()
-        throws Exception
+    public void testConll2012Html() throws Exception
     {
         testOneWay(
                 createReaderDescription(Conll2012Reader.class,
-                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false), 
-                createEngineDescription(BratWriter.class,
-                        BratWriter.PARAM_FILENAME_EXTENSION, ".html"), 
-                "conll/2012/en-ref.html",
-                "conll/2012/en-orig.conll");
+                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false),
+                createEngineDescription(BratWriter.class, BratWriter.PARAM_FILENAME_EXTENSION,
+                        ".html"),
+                "conll/2012/en-ref.html", "conll/2012/en-orig.conll");
     }
 
     @Test
-    public void testConll2012Json()
-        throws Exception
+    public void testConll2012Json() throws Exception
     {
         testOneWay(
                 createReaderDescription(Conll2012Reader.class,
-                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false), 
-                createEngineDescription(BratWriter.class,
-                        BratWriter.PARAM_FILENAME_EXTENSION, ".json"), 
-                "conll/2012/en-ref.json",
-                "conll/2012/en-orig.conll");
+                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false),
+                createEngineDescription(BratWriter.class, BratWriter.PARAM_FILENAME_EXTENSION,
+                        ".json"),
+                "conll/2012/en-ref.json", "conll/2012/en-orig.conll");
     }
 
     @Test
-    public void testConll2012()
-        throws Exception
+    public void testConll2012() throws Exception
     {
         testOneWay(
                 createReaderDescription(Conll2012Reader.class,
-                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false), 
-                createEngineDescription(BratWriter.class), 
-                "conll/2012/en-ref.ann",
+                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false),
+                createEngineDescription(BratWriter.class), "conll/2012/en-ref.ann",
                 "conll/2012/en-orig.conll");
     }
 
     @Ignore("Test largely ok but due to same spans for constituents not stable, thus ignoring")
     @Test
-    public void testConll2012_2()
-        throws Exception
+    public void testConll2012_2() throws Exception
     {
-        testRoundTrip(
-                createReaderDescription(BratReader.class), 
-                createEngineDescription(BratWriter.class), 
-                "conll/2012/en-ref.ann");
+        testRoundTrip(createReaderDescription(BratReader.class),
+                createEngineDescription(BratWriter.class), "conll/2012/en-ref.ann");
     }
 
     @Test
-    public void testConll2012_3()
-        throws Exception
+    public void testConll2012_3() throws Exception
     {
         testOneWay(
-                createReaderDescription(Conll2012Reader.class,
-                        Conll2012Reader.PARAM_READ_LEMMA, false,
-                        Conll2012Reader.PARAM_READ_NAMED_ENTITY, false,
+                createReaderDescription(Conll2012Reader.class, Conll2012Reader.PARAM_READ_LEMMA,
+                        false, Conll2012Reader.PARAM_READ_NAMED_ENTITY, false,
                         Conll2012Reader.PARAM_READ_SEMANTIC_PREDICATE, false,
-                        Conll2012Reader.PARAM_READ_COREFERENCE, false, 
-                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false), 
-                createEngineDescription(BratWriter.class), 
-                "conll/2012/en-ref-min.ann",
+                        Conll2012Reader.PARAM_READ_COREFERENCE, false,
+                        Conll2012Reader.PARAM_USE_HEADER_METADATA, false),
+                createEngineDescription(BratWriter.class), "conll/2012/en-ref-min.ann",
                 "conll/2012/en-orig.conll");
     }
 
     @Test
-    public void testWithShortNames()
-        throws Exception
+    public void testWithShortNames() throws Exception
     {
-        testRoundTrip(
-                createReaderDescription(BratReader.class,
-                        BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS, asList(
-                                "Token -> de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
-                                "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
-                                "Location -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location")),
-                createEngineDescription(BratWriter.class,
-                        BratWriter.PARAM_ENABLE_TYPE_MAPPINGS, true), 
+        testRoundTrip(createReaderDescription(BratReader.class,
+                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
+                asList("Token -> de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
+                        "Location -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location")),
+                createEngineDescription(BratWriter.class, BratWriter.PARAM_ENABLE_TYPE_MAPPINGS,
+                        true),
                 "brat/document0a.ann");
     }
 
     @Test
-    public void testWithLongNames()
-        throws Exception
+    public void testWithLongNames() throws Exception
     {
-        testRoundTrip(
-                createReaderDescription(BratReader.class), 
-                createEngineDescription(BratWriter.class,
-                        BratWriter.PARAM_ENABLE_TYPE_MAPPINGS, false), 
+        testRoundTrip(createReaderDescription(BratReader.class),
+                createEngineDescription(BratWriter.class, BratWriter.PARAM_ENABLE_TYPE_MAPPINGS,
+                        false),
                 "brat/document0b.ann");
     }
 
     @Test
-    public void test1()
-        throws Exception
+    public void testBratWithNewlines() throws Exception
     {
-        testOneWay(
-                createReaderDescription(BratReader.class,
-                        BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS, asList(
-                                "Country -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location",
-                                "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
-                                "MERGE-ORG -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.MergeOrg"),
-                        BratReader.PARAM_RELATION_TYPE_MAPPINGS, asList(
-                                "Origin -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation"),
-                        BratReader.PARAM_RELATION_TYPES, asList(
-                                "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
-                createEngineDescription(BratWriter.class,
-                        BratWriter.PARAM_RELATION_TYPES, asList(
-                                "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
-                "brat/document1-ref.ann", 
-                "brat/document1.ann");
+        testRoundTrip(createReaderDescription(BratReader.class,
+                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
+                asList("Token -> de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
+                        "Location -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location")),
+                createEngineDescription(BratWriter.class, BratWriter.PARAM_ENABLE_TYPE_MAPPINGS,
+                        false),
+                "brat/document0c.ann");
     }
 
     @Test
-    public void testTextAnnotationWithSubcategorization()
-        throws Exception
+    public void test1() throws Exception
     {
-        testOneWay(
-                createReaderDescription(BratReader.class,
-                        BratReader.PARAM_TEXT_ANNOTATION_TYPES, 
-                                "de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity:value",
-                        BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS, asList(
-                                "Country -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
-                                "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
-                                "MERGE-ORG -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.MergeOrg"),
-                        BratReader.PARAM_RELATION_TYPE_MAPPINGS, asList(
-                                "Origin -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation"),
-                        BratReader.PARAM_RELATION_TYPES, asList(
-                                "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
-                createEngineDescription(BratWriter.class,
-                        BratWriter.PARAM_RELATION_TYPES, asList(
-                                "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
-                "brat/document1-ref-sub.ann", 
-                "brat/document1.ann");
+        testOneWay(createReaderDescription(BratReader.class,
+                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
+                asList("Country -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location",
+                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization",
+                        "MERGE-ORG -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.MergeOrg"),
+                BratReader.PARAM_RELATION_TYPE_MAPPINGS,
+                asList("Origin -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation"),
+                BratReader.PARAM_RELATION_TYPES,
+                asList("de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
+                createEngineDescription(BratWriter.class, BratWriter.PARAM_RELATION_TYPES, asList(
+                        "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
+                "brat/document1-ref.ann", "brat/document1.ann");
+    }
+
+    @Test
+    public void testTextAnnotationWithSubcategorization() throws Exception
+    {
+        testOneWay(createReaderDescription(BratReader.class, BratReader.PARAM_TEXT_ANNOTATION_TYPES,
+                "de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity:value",
+                BratReader.PARAM_TEXT_ANNOTATION_TYPE_MAPPINGS,
+                asList("Country -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
+                        "Organization -> de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
+                        "MERGE-ORG -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.MergeOrg"),
+                BratReader.PARAM_RELATION_TYPE_MAPPINGS,
+                asList("Origin -> de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation"),
+                BratReader.PARAM_RELATION_TYPES,
+                asList("de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
+                createEngineDescription(BratWriter.class, BratWriter.PARAM_RELATION_TYPES, asList(
+                        "de.tudarmstadt.ukp.dkpro.core.io.brat.type.AnnotationRelation:source:target{A}:value")),
+                "brat/document1-ref-sub.ann", "brat/document1.ann");
     }
 
     @Rule

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotationTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotationTest.java
@@ -38,4 +38,23 @@ public class BratTextAnnotationTest
         BratTextAnnotation v = BratTextAnnotation.parse(in);
         assertEquals(in, v.toString());
     }
+    
+    @Test
+    public void parseTestDiscontinous1()
+    {
+        final String in = "T1\tOrganization 0 13;14 43\tInternational Business Machines Corporation";
+        final String out = "T1\tOrganization 0 43\tInternational Business Machines Corporation";
+        BratTextAnnotation v = BratTextAnnotation.parse(in);
+        assertEquals(out, v.toString());
+    }
+    
+    @Test
+    public void parseTestDiscontinous2()
+    {
+        final String in = "T1\tOrganization 0 13;15 43\tInternational Business Machines Corporation";
+        final String out = "T1\tOrganization 0 13;15 43\tInternational";
+        BratTextAnnotation v = BratTextAnnotation.parse(in);
+        System.out.println(v);
+        assertEquals(out, v.toString());
+    }
 }

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotationTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotationTest.java
@@ -27,15 +27,15 @@ public class BratTextAnnotationTest
     public void parseTest()
     {
         final String in = "T1\tOrganization 0 43\tInternational Business Machines Corporation";
-        BratTextAnnotation v = BratTextAnnotation.parse(in);
-        assertEquals(in, v.toString());
+        BratTextAnnotation[] v = BratTextAnnotation.parse(in);
+        assertEquals(in, v[0].toString());
     }
 
     @Test
     public void parseTestZeroLength()
     {
         final String in = "T1\tOrganization 0 0\t";
-        BratTextAnnotation v = BratTextAnnotation.parse(in);
-        assertEquals(in, v.toString());
+        BratTextAnnotation[] v = BratTextAnnotation.parse(in);
+        assertEquals(in, v[0].toString());
     }
 }

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotationTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotationTest.java
@@ -27,15 +27,15 @@ public class BratTextAnnotationTest
     public void parseTest()
     {
         final String in = "T1\tOrganization 0 43\tInternational Business Machines Corporation";
-        BratTextAnnotation[] v = BratTextAnnotation.parse(in);
-        assertEquals(in, v[0].toString());
+        BratTextAnnotation v = BratTextAnnotation.parse(in);
+        assertEquals(in, v.toString());
     }
 
     @Test
     public void parseTestZeroLength()
     {
         final String in = "T1\tOrganization 0 0\t";
-        BratTextAnnotation[] v = BratTextAnnotation.parse(in);
-        assertEquals(in, v[0].toString());
+        BratTextAnnotation v = BratTextAnnotation.parse(in);
+        assertEquals(in, v.toString());
     }
 }

--- a/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotationTest.java
+++ b/dkpro-core-io-brat-asl/src/test/java/de/tudarmstadt/ukp/dkpro/core/io/brat/internal/model/BratTextAnnotationTest.java
@@ -40,21 +40,12 @@ public class BratTextAnnotationTest
     }
     
     @Test
-    public void parseTestDiscontinous1()
+    public void parseTestDiscontinousMergeFragments()
     {
         final String in = "T1\tOrganization 0 13;14 43\tInternational Business Machines Corporation";
         final String out = "T1\tOrganization 0 43\tInternational Business Machines Corporation";
         BratTextAnnotation v = BratTextAnnotation.parse(in);
         assertEquals(out, v.toString());
     }
-    
-    @Test
-    public void parseTestDiscontinous2()
-    {
-        final String in = "T1\tOrganization 0 13;15 43\tInternational Business Machines Corporation";
-        final String out = "T1\tOrganization 0 13;15 43\tInternational";
-        BratTextAnnotation v = BratTextAnnotation.parse(in);
-        System.out.println(v);
-        assertEquals(out, v.toString());
-    }
+
 }

--- a/dkpro-core-io-brat-asl/src/test/resources/brat/document0c.ann
+++ b/dkpro-core-io-brat-asl/src/test/resources/brat/document0c.ann
@@ -1,0 +1,8 @@
+T1	Token 0 4	This
+T2	Token 5 7;8 9	is a
+T3	Token 10 14	test
+T4	Token 14 15	.
+E1	Token:T1
+E2	Token:T2
+E3	Token:T3
+E4	Token:T4

--- a/dkpro-core-io-brat-asl/src/test/resources/brat/document0c.txt
+++ b/dkpro-core-io-brat-asl/src/test/resources/brat/document0c.txt
@@ -1,0 +1,2 @@
+This is
+a test.

--- a/dkpro-core-io-brat-asl/src/test/resources/brat/document0d-ref.ann
+++ b/dkpro-core-io-brat-asl/src/test/resources/brat/document0d-ref.ann
@@ -1,0 +1,10 @@
+T1	Token 0 4	This
+T2	Token 5 7	is
+T3	Token 9 10	n
+T4	Token 11 21	other test
+T5	Token 21 22	.
+E1	Token:T1
+E2	Token:T2
+E3	Token:T3
+E4	Token:T4
+E5	Token:T5

--- a/dkpro-core-io-brat-asl/src/test/resources/brat/document0d.ann
+++ b/dkpro-core-io-brat-asl/src/test/resources/brat/document0d.ann
@@ -1,0 +1,8 @@
+T1	Token 0 4	This
+T2	Token 5 7;9 10	is n
+T3	Token 11 21	other test
+T4	Token 21 22	.
+E1	Token:T1
+E2	Token:T2
+E3	Token:T3
+E4	Token:T4

--- a/dkpro-core-io-brat-asl/src/test/resources/brat/document0d.txt
+++ b/dkpro-core-io-brat-asl/src/test/resources/brat/document0d.txt
@@ -1,0 +1,2 @@
+This is
+an other test.


### PR DESCRIPTION
As discussed there #1247 : 

This pull request 

1. makes reader be able to ingest brat discontinuous annotation :
    - case 1: fragments are far from 0 to one character -> it merges fragments into one annotation
    - case 2: fragments are fare from 2 to more characters -> it generates multiple annotations
2. makes writer be able to generate discontinuous annotations:
    - when the covered text contains one or multiple newlines, it generates one fragment per newline or group of newlines

Some tests have been added. The implementation also use multilple span for a BratTextAnnotations and is back compatible with regular - not discontinuous annotations as discussed in the issue
