### PR TITLE
#1286 - Tika 100000 characters Limit

### DIFF
--- a/dkpro-core-io-tika-asl/src/main/java/org/dkpro/core/io/tika/TikaReader.java
+++ b/dkpro-core-io-tika-asl/src/main/java/org/dkpro/core/io/tika/TikaReader.java
@@ -57,6 +57,14 @@ public class TikaReader
     @ConfigurationParameter(name = PARAM_PARSE_EMBEDDED_DOCUMENTS, mandatory = false,
             defaultValue = "false")
     private boolean parseEmbeddedDocuments;
+    
+    /**
+     * Internal buffer size. If the buffer size is exceeded, the reader will throw an exception 
+     * (-1 means unlimited size).
+     */
+    public static final String PARAM_BUFFER_SIZE = "bufferSize";
+    @ConfigurationParameter(name = PARAM_BUFFER_SIZE, mandatory = false, defaultValue = "-1")
+    private int bufferSize;
 
     // The Tika parser
     private AutoDetectParser parser;
@@ -83,7 +91,7 @@ public class TikaReader
         initCas(cas, fileResource);
 
         // Parse the document, docText stores the parsed text
-        BodyContentHandler handler = new BodyContentHandler();
+        BodyContentHandler handler = new BodyContentHandler(bufferSize);
         // Give hints to NameDetector about the filename
         Metadata metadata = new Metadata();
         metadata.set(Metadata.RESOURCE_NAME_KEY, new File(fileResource.getPath()).getName());


### PR DESCRIPTION
- Added parameter to configure the internal buffer size.
- Use an unlimited buffer by default.