### PR TITLE
#1358 - Improve error messages in TSV3

### DIFF
--- a/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/Tsv3XCasDocumentBuilder.java
+++ b/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/Tsv3XCasDocumentBuilder.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
@@ -133,8 +134,24 @@ public class Tsv3XCasDocumentBuilder
                     end = targetFS.getEnd();
                 }
                 
-                TsvToken beginToken = tokenBeginIndex.floorEntry(begin).getValue();
-                TsvToken endToken = tokenEndIndex.ceilingEntry(end).getValue();
+                Entry<Integer, TsvToken> beginTokenEntry = tokenBeginIndex.floorEntry(begin);
+                if (beginTokenEntry == null) {
+                    throw new IllegalStateException(
+                            "Unable to find begin token starting at or before " + begin
+                                    + " (first token starts at "
+                                    + tokenBeginIndex.pollFirstEntry().getKey()
+                                    + ") for annotation: " + annotation);
+                }
+
+                Entry<Integer, TsvToken> endTokenEntry = tokenEndIndex.ceilingEntry(end);
+                if (endTokenEntry == null) {
+                    throw new IllegalStateException("Unable to find end token ending at or after "
+                            + end + " (last token ends at " + tokenEndIndex.pollLastEntry().getKey()
+                            + ") for annotation: " + annotation);
+                }
+                
+                TsvToken beginToken = beginTokenEntry.getValue();
+                TsvToken endToken = endTokenEntry.getValue();
                 
                 // For zero-width annotations, the begin token must match the end token.
                 // Zero-width annotations between two directly adjacent tokens are always


### PR DESCRIPTION
- Improve error messages in TSV3 when an annotation cannot be persisted because it starts before the first token or ends beyond the last token.