### PR TITLE
#1337 - Connl2012 writer uses WordSense, but does not declare it

### DIFF
--- a/dkpro-core-io-conll-asl/src/main/java/org/dkpro/core/io/conll/Conll2012Reader.java
+++ b/dkpro-core-io-conll-asl/src/main/java/org/dkpro/core/io/conll/Conll2012Reader.java
@@ -79,13 +79,16 @@ import eu.openminted.share.annotations.api.DocumentationResource;
 @MimeTypeCapability({MimeTypes.TEXT_X_CONLL_2012})
 @TypeCapability(
         outputs = { 
+                "de.tudarmstadt.ukp.dkpro.core.api.coref.type.CoreferenceChain",
+                "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS",
                 "de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData",
+                "de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
                 "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence",
                 "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
-                "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS",
                 "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma",
                 "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemPred",
-                "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemArg"})
+                "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemArg",
+                "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.WordSense" })
 public class Conll2012Reader
     extends JCasResourceCollectionReader_ImplBase
 {

--- a/dkpro-core-io-conll-asl/src/main/java/org/dkpro/core/io/conll/Conll2012Writer.java
+++ b/dkpro-core-io-conll-asl/src/main/java/org/dkpro/core/io/conll/Conll2012Writer.java
@@ -70,13 +70,16 @@ import eu.openminted.share.annotations.api.DocumentationResource;
 @MimeTypeCapability({MimeTypes.TEXT_X_CONLL_2012})
 @TypeCapability(
         inputs = { 
+                "de.tudarmstadt.ukp.dkpro.core.api.coref.type.CoreferenceChain",
+                "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS",
                 "de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData",
+                "de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity",
                 "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence",
                 "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
-                "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS",
                 "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma",
                 "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemPred",
-                "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemArg" })
+                "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemArg",
+                "de.tudarmstadt.ukp.dkpro.core.api.semantics.type.WordSense" })
 public class Conll2012Writer
     extends JCasFileWriter_ImplBase
 {


### PR DESCRIPTION
- Added capabilities for CoreferenceHain, NamedEntity, and WordSense to CoNLL 2012 reader and writer