### PR TITLE
#1379 - Add generic XML types

### DIFF
--- a/dkpro-core-api-xml-asl/.activate-run-jcasgen
+++ b/dkpro-core-api-xml-asl/.activate-run-jcasgen
@@ -1,0 +1,1 @@
+Marker to activate run-jcasgen profile.

--- a/dkpro-core-api-xml-asl/LICENSE.txt
+++ b/dkpro-core-api-xml-asl/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dkpro-core-api-xml-asl/pom.xml
+++ b/dkpro-core-api-xml-asl/pom.xml
@@ -1,0 +1,46 @@
+<!--
+  Copyright 2010
+  Ubiquitous Knowledge Processing (UKP) Lab
+  Technische Universität Darmstadt
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>dkpro-core-asl</artifactId>
+    <groupId>org.dkpro.core</groupId>
+    <version>1.11.0-SNAPSHOT</version>
+    <relativePath>../dkpro-core-asl</relativePath>
+  </parent>
+  <artifactId>dkpro-core-api-xml-asl</artifactId>
+  <packaging>jar</packaging>
+  <name>DKPro Core ASL - XML API</name>
+  <url>https://dkpro.github.io/dkpro-core/</url>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimafit-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/dkpro-core-api-xml-asl/src/main/java/org/dkpro/core/api/xml/Cas2SaxEvents.java
+++ b/dkpro-core-api-xml-asl/src/main/java/org/dkpro/core/api/xml/Cas2SaxEvents.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.api.xml;
+
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.uima.fit.util.JCasUtil.selectSingle;
+
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.jcas.JCas;
+import org.dkpro.core.api.xml.type.XmlAttribute;
+import org.dkpro.core.api.xml.type.XmlDocument;
+import org.dkpro.core.api.xml.type.XmlElement;
+import org.dkpro.core.api.xml.type.XmlTextNode;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+public class Cas2SaxEvents
+{
+    private final ContentHandler handler;
+
+    public Cas2SaxEvents(ContentHandler aHandler)
+    {
+        handler = aHandler;
+    }
+    
+    public void process(JCas aJCas) throws SAXException
+    {
+        XmlDocument doc = selectSingle(aJCas, XmlDocument.class);
+
+        process(doc);
+    }
+
+    public void process(XmlDocument aDoc) throws SAXException
+    {
+        handler.startDocument();
+
+        if (aDoc.getRoot() == null) {
+            throw new SAXException("Document has no root element");
+        }
+        
+        process(aDoc.getRoot());
+
+        handler.endDocument();
+    }
+
+    public void process(XmlElement aElement) throws SAXException
+    {
+        AttributesImpl attributes = new AttributesImpl();
+        
+        if (aElement.getAttributes() != null) {
+            for (FeatureStructure attrFS : aElement.getAttributes()) {
+                XmlAttribute attr = (XmlAttribute) attrFS;
+                attributes.addAttribute(defaultString(attr.getUri()),
+                        defaultString(attr.getLocalName()), defaultString(attr.getQName()),
+                        defaultString(attr.getValueType(), "CDATA"),
+                        defaultString(attr.getValue()));
+            }
+        }
+        
+        String uri = defaultString(aElement.getUri());
+        String localName = defaultString(aElement.getLocalName());
+        String qName = defaultString(aElement.getQName());
+        
+        handler.startElement(uri, localName, qName, attributes);
+        
+        if (aElement.getChildren() != null) {
+            for (FeatureStructure child : aElement.getChildren()) {
+                if (child instanceof XmlElement) {
+                    process((XmlElement) child);
+                }
+                else if (child instanceof XmlTextNode) {
+                    process((XmlTextNode) child);
+                }
+            }
+        }
+        
+        handler.endElement(uri, localName, qName);
+    }
+
+    private void process(XmlTextNode aChild) throws SAXException
+    {
+        char[] text = aChild.getCoveredText().toCharArray();
+        handler.characters(text, 0, text.length);
+    }
+}

--- a/dkpro-core-api-xml-asl/src/main/java/org/dkpro/core/api/xml/CasXmlHandler.java
+++ b/dkpro-core-api-xml-asl/src/main/java/org/dkpro/core/api/xml/CasXmlHandler.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.api.xml;
+
+import static org.apache.commons.lang3.StringUtils.trimToNull;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.cas.FSArray;
+import org.dkpro.core.api.xml.type.XmlAttribute;
+import org.dkpro.core.api.xml.type.XmlDocument;
+import org.dkpro.core.api.xml.type.XmlElement;
+import org.dkpro.core.api.xml.type.XmlNode;
+import org.dkpro.core.api.xml.type.XmlTextNode;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class CasXmlHandler
+    extends DefaultHandler
+{
+    private final JCas jcas;
+    private final StringBuilder text;
+    private final Deque<StackFrame> stack;
+
+    private XmlDocument docNode;
+    private boolean captureText = true;
+
+    public CasXmlHandler(JCas aJCas)
+    {
+        jcas = aJCas;
+        text = new StringBuilder();
+        stack = new ArrayDeque<>();
+    }
+    
+    @Override
+    public void startDocument() throws SAXException
+    {
+        if (docNode != null || !stack.isEmpty() || text.length() != 0) {
+            throw new SAXException(
+                    "Illegal document start event when data has already been seen.");
+        }
+        
+        docNode = new XmlDocument(jcas);
+        docNode.setBegin(text.length());
+    }
+    
+    @Override
+    public void endDocument() throws SAXException
+    {
+        docNode.setEnd(text.length());
+        docNode.addToIndexes();
+        
+        jcas.setDocumentText(text.toString());
+    };
+
+    @Override
+    public void startElement(String aUri, String aLocalName, String aQName, Attributes aAttributes)
+        throws SAXException
+    {
+        if (docNode == null) {
+            throw new SAXException(
+                    "Illegal element start event when document start has not been seen.");
+        }
+
+        XmlElement element = new XmlElement(jcas);
+        element.setBegin(text.length());
+        element.setUri(trimToNull(aUri));
+        element.setLocalName(trimToNull(aLocalName));
+        element.setQName(trimToNull(aQName));
+        
+        if (aAttributes.getLength() > 0) {
+            FSArray attributes = new FSArray(jcas, aAttributes.getLength());
+            for (int i = 0; i < aAttributes.getLength(); i++) {
+                XmlAttribute attribute = new XmlAttribute(jcas);
+                attribute.setUri(trimToNull(aAttributes.getURI(i)));
+                attribute.setLocalName(trimToNull(aAttributes.getLocalName(i)));
+                attribute.setQName(trimToNull(aAttributes.getQName(i)));
+                attribute.setValueType(trimToNull(aAttributes.getType(i)));
+                attribute.setValue(aAttributes.getValue(i));
+                attributes.set(i, attribute);
+            }
+            element.setAttributes(attributes);
+        }
+        
+        attachToParent(element);
+        
+        boolean capture;
+        StackFrame parentFrame = stack.peek();
+        if (parentFrame != null) {
+            capture = parentFrame.isCaptureText();
+        }
+        else {
+            capture = captureText;
+        }
+        
+        stack.push(new StackFrame(element, capture));
+    }
+    
+    @Override
+    public void endElement(String aUri, String aLocalName, String aQName) throws SAXException
+    {
+        StackFrame frame = stack.pop();
+        
+        XmlElement element = frame.getElement();
+        element.setEnd(text.length());
+
+        // Fill in children
+        if (!frame.getChildren().isEmpty()) {
+            FSArray children = new FSArray(jcas, frame.getChildren().size());
+            for (int i = 0; i < frame.getChildren().size(); i++) {
+                children.set(i, frame.getChildren().get(i));
+            }
+            element.setChildren(children);
+        }
+        
+        element.addToIndexes();
+    }
+    
+    @Override
+    public void characters(char[] aCh, int aStart, int aLength) throws SAXException
+    {
+        XmlTextNode textNode = new XmlTextNode(jcas);
+        textNode.setBegin(text.length());
+        
+        if (stack.peek().isCaptureText()) {
+            text.append(aCh, aStart, aLength);
+            textNode.setCaptured(true);
+        }
+        else {
+            textNode.setText(new String(aCh, aStart, aLength));
+            textNode.setCaptured(false);
+        }
+        
+        textNode.setEnd(text.length());
+        textNode.addToIndexes();
+
+        attachToParent(textNode);
+    }
+    
+    @Override
+    public void ignorableWhitespace(char[] aCh, int aStart, int aLength) throws SAXException
+    {
+        characters(aCh, aStart, aLength);
+    }
+    
+    private void attachToParent(XmlNode aNode)
+    {
+        StackFrame parentFrame = stack.peek();
+        if (parentFrame != null) {
+            aNode.setParent(parentFrame.getElement());
+            parentFrame.addChild(aNode);
+        }
+        else {
+            docNode.setRoot((XmlElement) aNode);
+        }
+    }
+    
+    public CharSequence getText()
+    {
+        return text;
+    }
+    
+    public Collection<StackFrame> getStack()
+    {
+        return Collections.unmodifiableCollection(stack);
+    }
+    
+    public XmlElement getCurrentElement()
+    {
+        return stack.peek().getElement();
+    }
+    
+    public void captureText(boolean aCapture)
+    {
+        if (stack.isEmpty()) {
+            captureText = aCapture;
+        }
+        else {
+            stack.peek().setCaptureText(aCapture);
+        }
+    }
+    
+    private static class StackFrame
+    {
+        private final XmlElement element;
+        private final List<XmlNode> children = new ArrayList<>();
+        private boolean captureText;
+
+        public StackFrame(XmlElement aElement, boolean aCaptureText)
+        {
+            element = aElement;
+            captureText = aCaptureText;
+        }
+
+        public XmlElement getElement()
+        {
+            return element;
+        }
+        
+        public void addChild(XmlNode aChild)
+        {
+            children.add(aChild);
+        }
+
+        public List<XmlNode> getChildren()
+        {
+            return children;
+        }
+        
+        public boolean isCaptureText()
+        {
+            return captureText;
+        }
+        
+        public void setCaptureText(boolean aCaptureText)
+        {
+            captureText = aCaptureText;
+        }
+    }
+}

--- a/dkpro-core-api-xml-asl/src/main/resources/META-INF/org.apache.uima.fit/types.txt
+++ b/dkpro-core-api-xml-asl/src/main/resources/META-INF/org.apache.uima.fit/types.txt
@@ -1,0 +1,1 @@
+classpath*:desc/type/XmlStructure.xml

--- a/dkpro-core-api-xml-asl/src/main/resources/desc/type/XmlStructure.xml
+++ b/dkpro-core-api-xml-asl/src/main/resources/desc/type/XmlStructure.xml
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
+        
+  
+  
+  <name>XML Structure</name>
+        
+  
+  
+  <description/>
+        
+  
+  
+  <version>${version}</version>
+        
+  
+  
+  <vendor>Ubiquitous Knowledge Processing (UKP) Lab, Technische Universität Darmstadt</vendor>
+        
+  
+  
+  <types>
+                
+    
+    
+    <typeDescription>
+                        
+      
+      
+      <name>org.dkpro.core.api.xml.type.XmlElement</name>
+                        
+      
+      
+      <description>XML element</description>
+                        
+      
+      
+      <supertypeName>org.dkpro.core.api.xml.type.XmlNode</supertypeName>
+                        
+      
+      
+      <features>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>uri</name>
+                                        
+          
+          
+          <description>Namespace URI of the element.</description>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>localName</name>
+                                        
+          
+          
+          <description>Local name of the XML element.</description>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>attributes</name>
+                                        
+          
+          
+          <description>Array of attributes of the XML element.</description>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.FSArray</rangeTypeName>
+                                        
+          
+          
+          <elementType>org.dkpro.core.api.xml.type.XmlAttribute</elementType>
+                                      
+        
+        
+        </featureDescription>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>children</name>
+                                        
+          
+          
+          <description>Children of this XML element.</description>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.FSArray</rangeTypeName>
+                                        
+          
+          
+          <elementType>org.dkpro.core.api.xml.type.XmlNode</elementType>
+                                      
+        
+        
+        </featureDescription>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>qName</name>
+                                        
+          
+          
+          <description/>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                              
+      
+      
+      </features>
+                      
+    
+    
+    </typeDescription>
+                
+    
+    
+    <typeDescription>
+                        
+      
+      
+      <name>org.dkpro.core.api.xml.type.XmlAttribute</name>
+                        
+      
+      
+      <description/>
+                        
+      
+      
+      <supertypeName>uima.cas.TOP</supertypeName>
+                        
+      
+      
+      <features>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>uri</name>
+                                        
+          
+          
+          <description>Namespace URI of the attribute.</description>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>localName</name>
+                                        
+          
+          
+          <description>Local name of the attribute.</description>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>value</name>
+                                        
+          
+          
+          <description>Value of the XML attribute.</description>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>qName</name>
+                                        
+          
+          
+          <description/>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>valueType</name>
+                                        
+          
+          
+          <description/>
+                                        
+          
+          
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                              
+      
+      
+      </features>
+                      
+    
+    
+    </typeDescription>
+                
+    
+    
+    <typeDescription>
+                        
+      
+      
+      <name>org.dkpro.core.api.xml.type.XmlNode</name>
+                        
+      
+      
+      <description>Supertype for XmlElements and XmlTextNodes.</description>
+                        
+      
+      
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+                        
+      
+      
+      <features>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>parent</name>
+                                        
+          
+          
+          <description/>
+                                        
+          
+          
+          <rangeTypeName>org.dkpro.core.api.xml.type.XmlElement</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                              
+      
+      
+      </features>
+                      
+    
+    
+    </typeDescription>
+                
+    
+    
+    <typeDescription>
+                        
+      
+      
+      <name>org.dkpro.core.api.xml.type.XmlDocument</name>
+                        
+      
+      
+      <description>XML document</description>
+                        
+      
+      
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+                        
+      
+      
+      <features>
+                                
+        
+        
+        <featureDescription>
+                                        
+          
+          
+          <name>root</name>
+                                        
+          
+          
+          <description>Root element of the XML document.</description>
+                                        
+          
+          
+          <rangeTypeName>org.dkpro.core.api.xml.type.XmlElement</rangeTypeName>
+                                      
+        
+        
+        </featureDescription>
+                              
+      
+      
+      </features>
+                      
+    
+    
+    </typeDescription>
+                
+    
+    
+    <typeDescription>
+                        
+      
+      
+      <name>org.dkpro.core.api.xml.type.XmlTextNode</name>
+                        
+      
+      
+      <description>XML text node.</description>
+                        
+      
+      
+      <supertypeName>org.dkpro.core.api.xml.type.XmlNode</supertypeName>
+                      
+    
+    
+      <features>
+                
+        <featureDescription>
+                    
+          <name>text</name>
+                    
+          <description/>
+                    
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+                  
+        </featureDescription>
+                
+        <featureDescription>
+                    
+          <name>captured</name>
+                    
+          <description>Whether the text node has been added to the document text.</description>
+                    
+          <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+                  
+        </featureDescription>
+              
+      </features>
+    </typeDescription>
+          
+  
+  </types>
+      
+
+
+</typeSystemDescription>

--- a/dkpro-core-api-xml-asl/suppressions.xml
+++ b/dkpro-core-api-xml-asl/suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+"-//Puppy Crawl//DTD Suppressions 1.1//EN"
+"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress files=".*[/\\]target[/\\].*" checks=".*"/>
+</suppressions>

--- a/dkpro-core-asl/pom.xml
+++ b/dkpro-core-asl/pom.xml
@@ -135,6 +135,11 @@
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
+        <artifactId>dkpro-core-api-xml-asl</artifactId>
+        <version>1.11.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-castransformation-asl</artifactId>
         <version>1.11.0-SNAPSHOT</version>
       </dependency>
@@ -450,11 +455,6 @@
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
-        <artifactId>dkpro-core-ngrams-asl</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-mystem-asl</artifactId>
         <version>1.11.0-SNAPSHOT</version>
       </dependency>      
@@ -567,6 +567,7 @@
     <module>../dkpro-core-api-transform-asl</module>
     <module>../dkpro-core-api-ner-asl</module>
     <module>../dkpro-core-api-frequency-asl</module>
+    <module>../dkpro-core-api-xml-asl</module>
     <!-- FS modules -->
     <module>../dkpro-core-fs-hdfs-asl</module>
     <!-- IO modules -->

--- a/dkpro-core-io-html-asl/pom.xml
+++ b/dkpro-core-io-html-asl/pom.xml
@@ -72,6 +72,10 @@
       <artifactId>dkpro-core-api-io-asl</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-xml-asl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>eu.openminted.share.annotations</groupId>
       <artifactId>omtd-share-annotations-api</artifactId>
     </dependency>
@@ -81,8 +85,23 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-testing-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-io-xmi-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-io-xml-asl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dkpro-core-io-html-asl/src/main/java/org/dkpro/core/io/html/internal/JSoupUtil.java
+++ b/dkpro-core-io-html-asl/src/main/java/org/dkpro/core/io/html/internal/JSoupUtil.java
@@ -22,7 +22,8 @@
  */
 package org.dkpro.core.io.html.internal;
 
-import org.jsoup.helper.StringUtil;
+import static org.jsoup.helper.StringUtil.appendNormalisedWhitespace;
+
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
@@ -35,34 +36,37 @@ public final class JSoupUtil
     /*
      * org.jsoup.nodes.TextNode.lastCharIsWhitespace(StringBuilder)
      */
-    public static boolean lastCharIsWhitespace(StringBuilder sb) {
+    public static boolean lastCharIsWhitespace(CharSequence sb)
+    {
         return sb.length() != 0 && sb.charAt(sb.length() - 1) == ' ';
     }
-    
+
     /*
      * org.jsoup.nodes.Element.appendNormalisedText(StringBuilder, TextNode)
      */
-    public static void appendNormalisedText(StringBuilder accum, TextNode textNode) {
+    public static void appendNormalisedText(StringBuilder accum, TextNode textNode)
+    {
         String text = textNode.getWholeText();
 
         if (preserveWhitespace(textNode.parentNode())) {
             accum.append(text);
         }
         else {
-            StringUtil.appendNormalisedWhitespace(accum, text, lastCharIsWhitespace(accum));
+            appendNormalisedWhitespace(accum, text, lastCharIsWhitespace(accum));
         }
     }
-    
+
     /*
      * org.jsoup.nodes.Element.preserveWhitespace(Node)
      */
-    public static boolean preserveWhitespace(Node node) {
+    public static boolean preserveWhitespace(Node node)
+    {
         // looks only at this element and one level up, to prevent recursion & needless stack
         // searches
         if (node != null && node instanceof Element) {
             Element element = (Element) node;
-            return element.tag().preserveWhitespace() ||
-                element.parent() != null && element.parent().tag().preserveWhitespace();
+            return element.tag().preserveWhitespace()
+                    || element.parent() != null && element.parent().tag().preserveWhitespace();
         }
         return false;
     }

--- a/dkpro-core-io-html-asl/src/main/java/org/dkpro/core/io/html/internal/TrimUtils.java
+++ b/dkpro-core-io-html-asl/src/main/java/org/dkpro/core/io/html/internal/TrimUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.io.html.internal;
+
+public class TrimUtils
+{
+    /**
+     * Remove trailing or leading whitespace from the annotation.
+     * @param aText the text.
+     * @param aSpan the offsets.
+     */
+    public static void trim(CharSequence aText, int[] aSpan)
+    {
+        int begin = aSpan[0];
+        int end = aSpan[1] - 1;
+
+        while (
+                (begin < (aText.length() - 1))
+                && trimChar(aText.charAt(begin))
+        ) {
+            begin ++;
+        }
+        while (
+                (end > 0)
+                && trimChar(aText.charAt(end))
+        ) {
+            end --;
+        }
+
+        end++;
+
+        aSpan[0] = begin;
+        aSpan[1] = end;
+    }
+
+    private static boolean trimChar(final char aChar)
+    {
+        switch (aChar) {
+        case '\n':     return true; // Line break
+        case '\r':     return true; // Carriage return
+        case '\t':     return true; // Tab
+        case '\u200E': return true; // LEFT-TO-RIGHT MARK
+        case '\u200F': return true; // RIGHT-TO-LEFT MARK
+        case '\u2028': return true; // LINE SEPARATOR
+        case '\u2029': return true; // PARAGRAPH SEPARATOR
+        default:
+            return  Character.isWhitespace(aChar);
+        }
+    }
+}

--- a/dkpro-core-io-html-asl/src/test/java/org/dkpro/core/io/html/HtmlDocumentReaderTest.java
+++ b/dkpro-core-io-html-asl/src/test/java/org/dkpro/core/io/html/HtmlDocumentReaderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.io.html;
+
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+import static org.apache.uima.fit.util.JCasUtil.select;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dkpro.core.testing.IOTestRunner.testOneWay;
+
+import org.apache.uima.collection.CollectionReader;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.dkpro.core.io.xmi.XmiWriter;
+import org.dkpro.core.io.xml.XmlDocumentWriter;
+import org.dkpro.core.testing.DkproTestContext;
+import org.junit.Rule;
+import org.junit.Test;
+
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Heading;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph;
+
+public class HtmlDocumentReaderTest
+{
+    @Test
+    public void testReadFileWithOnlyBody()
+        throws Exception
+    {
+        JCas jcas = JCasFactory.createJCas();
+        
+        CollectionReader reader = createReader(HtmlDocumentReader.class,
+                HtmlDocumentReader.PARAM_SOURCE_LOCATION, "src/test/resources/html/test.html",
+                HtmlDocumentReader.PARAM_LANGUAGE, "en");
+        
+        reader.getNext(jcas.getCas());
+
+        assertThat(jcas.getDocumentText())
+                .isEqualTo(" Heading  This is the first paragraph.   This is the second paragraph.   ");
+
+        assertThat(select(jcas, Heading.class))
+                .extracting(Heading::getCoveredText)
+                .containsExactly("Heading");
+
+        assertThat(select(jcas, Paragraph.class))
+                .extracting(Paragraph::getCoveredText)
+                .containsExactly("This is the first paragraph.", "This is the second paragraph.");
+    }
+    
+    @Test
+    public void testReadFileWithOnlyBodyAndWriteAsXml()
+        throws Exception
+    {
+        testOneWay(
+                createReaderDescription(HtmlDocumentReader.class,
+                        HtmlDocumentReader.PARAM_LANGUAGE, "en"),
+                createEngineDescription(XmlDocumentWriter.class),
+                "html/test-document.xml", 
+                "html/test.html");
+    }
+    
+    @Test
+    public void testReadFileWithOnlyBodyAndWriteAsXmi()
+        throws Exception
+    {
+        testOneWay(
+                createReaderDescription(HtmlDocumentReader.class,
+                        HtmlDocumentReader.PARAM_LANGUAGE, "en"),
+                createEngineDescription(XmiWriter.class),
+                "html/test-document.xmi", 
+                "html/test.html");
+    }
+    
+    @Test
+    public void testReadFileWithHead()
+        throws Exception
+    {
+        JCas jcas = JCasFactory.createJCas();
+        
+        CollectionReader reader = createReader(HtmlDocumentReader.class,
+                HtmlDocumentReader.PARAM_SOURCE_LOCATION, "src/test/resources/html/test-with-head.html",
+                HtmlDocumentReader.PARAM_LANGUAGE, "en");
+        
+        reader.getNext(jcas.getCas());
+
+        assertThat(jcas.getDocumentText())
+                .isEqualTo(" Heading  This is the first paragraph.   This is the second paragraph.   ");
+
+        assertThat(select(jcas, Heading.class))
+                .extracting(Heading::getCoveredText)
+                .containsExactly("Heading");
+
+        assertThat(select(jcas, Paragraph.class))
+                .extracting(Paragraph::getCoveredText)
+                .containsExactly("This is the first paragraph.", "This is the second paragraph.");
+    }
+    
+    @Test
+    public void testReadFileWithHeadAndWriteAsXmi()
+        throws Exception
+    {
+        testOneWay(
+                createReaderDescription(HtmlDocumentReader.class,
+                        HtmlDocumentReader.PARAM_LANGUAGE, "en"),
+                createEngineDescription(XmiWriter.class),
+                "html/test-with-head.xmi", 
+                "html/test-with-head.html");
+    }
+
+    @Rule
+    public DkproTestContext testContext = new DkproTestContext();
+}

--- a/dkpro-core-io-html-asl/src/test/resources/html/test-document.xmi
+++ b/dkpro-core-io-html-asl/src/test/resources/html/test-document.xmi
@@ -2,23 +2,23 @@
     <cas:NULL xmi:id="0"/>
     <type3:DocumentMetaData xmi:id="1" sofa="12" begin="0" end="73" language="en" documentTitle="test.html" documentId="test.html" isLastSegment="false"/>
     <type9:XmlElement xmi:id="24" sofa="12" begin="0" end="73" children="34 44" qName="html"/>
-    <type9:XmlElement xmi:id="44" sofa="12" begin="0" end="73" parent="24" children="54 59 83 88 112 117 141 146" qName="body"/>
+    <type9:XmlElement xmi:id="44" sofa="12" begin="0" end="73" parent="24" children="54 61 87 94 120 127 153 160" qName="body"/>
     <type9:XmlElement xmi:id="34" sofa="12" begin="0" end="0" parent="24" qName="head"/>
-    <type9:XmlElement xmi:id="59" sofa="12" begin="1" end="8" parent="44" children="69" qName="h1"/>
-    <type9:XmlElement xmi:id="88" sofa="12" begin="9" end="39" parent="44" children="98" qName="p"/>
-    <type9:XmlElement xmi:id="117" sofa="12" begin="40" end="71" parent="44" children="127" qName="p"/>
-    <type9:XmlTextNode xmi:id="54" sofa="12" begin="0" end="1" parent="44"/>
-    <type9:XmlTextNode xmi:id="69" sofa="12" begin="1" end="8" parent="59"/>
-    <type9:XmlTextNode xmi:id="83" sofa="12" begin="8" end="9" parent="44"/>
-    <type9:XmlTextNode xmi:id="98" sofa="12" begin="9" end="39" parent="88"/>
-    <type9:XmlTextNode xmi:id="112" sofa="12" begin="39" end="40" parent="44"/>
-    <type9:XmlTextNode xmi:id="127" sofa="12" begin="40" end="71" parent="117"/>
-    <type9:XmlTextNode xmi:id="141" sofa="12" begin="71" end="72" parent="44"/>
-    <type9:XmlTextNode xmi:id="146" sofa="12" begin="72" end="73" parent="44"/>
-    <type5:Heading xmi:id="77" sofa="12" begin="1" end="8" divType="h1"/>
-    <type5:Paragraph xmi:id="106" sofa="12" begin="10" end="38" divType="p"/>
-    <type5:Paragraph xmi:id="135" sofa="12" begin="41" end="70" divType="p"/>
+    <type9:XmlElement xmi:id="61" sofa="12" begin="1" end="8" parent="44" children="71" qName="h1"/>
+    <type9:XmlElement xmi:id="94" sofa="12" begin="9" end="39" parent="44" children="104" qName="p"/>
+    <type9:XmlElement xmi:id="127" sofa="12" begin="40" end="71" parent="44" children="137" qName="p"/>
+    <type9:XmlTextNode xmi:id="54" sofa="12" begin="0" end="1" parent="44" captured="true"/>
+    <type9:XmlTextNode xmi:id="71" sofa="12" begin="1" end="8" parent="61" captured="true"/>
+    <type9:XmlTextNode xmi:id="87" sofa="12" begin="8" end="9" parent="44" captured="true"/>
+    <type9:XmlTextNode xmi:id="104" sofa="12" begin="9" end="39" parent="94" captured="true"/>
+    <type9:XmlTextNode xmi:id="120" sofa="12" begin="39" end="40" parent="44" captured="true"/>
+    <type9:XmlTextNode xmi:id="137" sofa="12" begin="40" end="71" parent="127" captured="true"/>
+    <type9:XmlTextNode xmi:id="153" sofa="12" begin="71" end="72" parent="44" captured="true"/>
+    <type9:XmlTextNode xmi:id="160" sofa="12" begin="72" end="73" parent="44" captured="true"/>
+    <type5:Heading xmi:id="81" sofa="12" begin="1" end="8" divType="h1"/>
+    <type5:Paragraph xmi:id="114" sofa="12" begin="10" end="38" divType="p"/>
+    <type5:Paragraph xmi:id="147" sofa="12" begin="41" end="70" divType="p"/>
     <type9:XmlDocument xmi:id="19" sofa="12" begin="0" end="73" root="24"/>
     <cas:Sofa xmi:id="12" sofaNum="1" sofaID="_InitialView" mimeType="text" sofaString=" Heading  This is the first paragraph.   This is the second paragraph.   "/>
-    <cas:View sofa="12" members="1 24 44 34 59 88 117 54 69 83 98 112 127 141 146 77 106 135 19"/>
+    <cas:View sofa="12" members="1 24 44 34 61 94 127 54 71 87 104 120 137 153 160 81 114 147 19"/>
 </xmi:XMI>

--- a/dkpro-core-io-html-asl/src/test/resources/html/test-document.xmi
+++ b/dkpro-core-io-html-asl/src/test/resources/html/test-document.xmi
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?><xmi:XMI xmlns:pos="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos.ecore" xmlns:tcas="http:///uima/tcas.ecore" xmlns:xmi="http://www.omg.org/XMI" xmlns:cas="http:///uima/cas.ecore" xmlns:tweet="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/tweet.ecore" xmlns:morph="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/morph.ecore" xmlns:dependency="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency.ecore" xmlns:type6="http:///de/tudarmstadt/ukp/dkpro/core/api/semantics/type.ecore" xmlns:type="http:///de/tudarmstadt/ukp/dkpro/core/api/anomaly/type.ecore" xmlns:type8="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type.ecore" xmlns:type3="http:///de/tudarmstadt/ukp/dkpro/core/api/metadata/type.ecore" xmlns:type9="http:///org/dkpro/core/api/xml/type.ecore" xmlns:type4="http:///de/tudarmstadt/ukp/dkpro/core/api/ner/type.ecore" xmlns:type5="http:///de/tudarmstadt/ukp/dkpro/core/api/segmentation/type.ecore" xmlns:type2="http:///de/tudarmstadt/ukp/dkpro/core/api/coref/type.ecore" xmlns:type7="http:///de/tudarmstadt/ukp/dkpro/core/api/structure/type.ecore" xmlns:constituent="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent.ecore" xmlns:chunk="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/chunk.ecore" xmi:version="2.0">
+    <cas:NULL xmi:id="0"/>
+    <type3:DocumentMetaData xmi:id="1" sofa="12" begin="0" end="73" language="en" documentTitle="test.html" documentId="test.html" isLastSegment="false"/>
+    <type9:XmlElement xmi:id="24" sofa="12" begin="0" end="73" children="34 44" qName="html"/>
+    <type9:XmlElement xmi:id="44" sofa="12" begin="0" end="73" parent="24" children="54 59 83 88 112 117 141 146" qName="body"/>
+    <type9:XmlElement xmi:id="34" sofa="12" begin="0" end="0" parent="24" qName="head"/>
+    <type9:XmlElement xmi:id="59" sofa="12" begin="1" end="8" parent="44" children="69" qName="h1"/>
+    <type9:XmlElement xmi:id="88" sofa="12" begin="9" end="39" parent="44" children="98" qName="p"/>
+    <type9:XmlElement xmi:id="117" sofa="12" begin="40" end="71" parent="44" children="127" qName="p"/>
+    <type9:XmlTextNode xmi:id="54" sofa="12" begin="0" end="1" parent="44"/>
+    <type9:XmlTextNode xmi:id="69" sofa="12" begin="1" end="8" parent="59"/>
+    <type9:XmlTextNode xmi:id="83" sofa="12" begin="8" end="9" parent="44"/>
+    <type9:XmlTextNode xmi:id="98" sofa="12" begin="9" end="39" parent="88"/>
+    <type9:XmlTextNode xmi:id="112" sofa="12" begin="39" end="40" parent="44"/>
+    <type9:XmlTextNode xmi:id="127" sofa="12" begin="40" end="71" parent="117"/>
+    <type9:XmlTextNode xmi:id="141" sofa="12" begin="71" end="72" parent="44"/>
+    <type9:XmlTextNode xmi:id="146" sofa="12" begin="72" end="73" parent="44"/>
+    <type5:Heading xmi:id="77" sofa="12" begin="1" end="8" divType="h1"/>
+    <type5:Paragraph xmi:id="106" sofa="12" begin="10" end="38" divType="p"/>
+    <type5:Paragraph xmi:id="135" sofa="12" begin="41" end="70" divType="p"/>
+    <type9:XmlDocument xmi:id="19" sofa="12" begin="0" end="73" root="24"/>
+    <cas:Sofa xmi:id="12" sofaNum="1" sofaID="_InitialView" mimeType="text" sofaString=" Heading  This is the first paragraph.   This is the second paragraph.   "/>
+    <cas:View sofa="12" members="1 24 44 34 59 88 117 54 69 83 98 112 127 141 146 77 106 135 19"/>
+</xmi:XMI>

--- a/dkpro-core-io-html-asl/src/test/resources/html/test-document.xml
+++ b/dkpro-core-io-html-asl/src/test/resources/html/test-document.xml
@@ -1,0 +1,10 @@
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</head>
+<body> 
+<h1>Heading</h1> 
+<p> This is the first paragraph. </p> 
+<p> This is the second paragraph. </p>  
+</body>
+</html>

--- a/dkpro-core-io-html-asl/src/test/resources/html/test-with-head.html
+++ b/dkpro-core-io-html-asl/src/test/resources/html/test-with-head.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    <h1>Heading</h1>
+    <p>
+      This is the first paragraph.
+    </p>
+    <p>
+      This is the second paragraph.
+    </p>
+  </body>
+</html>

--- a/dkpro-core-io-html-asl/src/test/resources/html/test-with-head.xmi
+++ b/dkpro-core-io-html-asl/src/test/resources/html/test-with-head.xmi
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><xmi:XMI xmlns:pos="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos.ecore" xmlns:tcas="http:///uima/tcas.ecore" xmlns:xmi="http://www.omg.org/XMI" xmlns:cas="http:///uima/cas.ecore" xmlns:tweet="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/tweet.ecore" xmlns:morph="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/morph.ecore" xmlns:dependency="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency.ecore" xmlns:type6="http:///de/tudarmstadt/ukp/dkpro/core/api/semantics/type.ecore" xmlns:type="http:///de/tudarmstadt/ukp/dkpro/core/api/anomaly/type.ecore" xmlns:type8="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type.ecore" xmlns:type3="http:///de/tudarmstadt/ukp/dkpro/core/api/metadata/type.ecore" xmlns:type9="http:///org/dkpro/core/api/xml/type.ecore" xmlns:type4="http:///de/tudarmstadt/ukp/dkpro/core/api/ner/type.ecore" xmlns:type5="http:///de/tudarmstadt/ukp/dkpro/core/api/segmentation/type.ecore" xmlns:type2="http:///de/tudarmstadt/ukp/dkpro/core/api/coref/type.ecore" xmlns:type7="http:///de/tudarmstadt/ukp/dkpro/core/api/structure/type.ecore" xmlns:constituent="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent.ecore" xmlns:chunk="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/chunk.ecore" xmi:version="2.0">
+    <cas:NULL xmi:id="0"/>
+    <type3:DocumentMetaData xmi:id="1" sofa="12" begin="0" end="73" language="en" documentTitle="test-with-head.html" documentId="test-with-head.html" isLastSegment="false"/>
+    <type9:XmlTextNode xmi:id="100" sofa="12" begin="0" end="1" parent="90" captured="true"/>
+    <type9:XmlTextNode xmi:id="44" sofa="12" begin="0" end="0" parent="34" text=" " captured="false"/>
+    <type9:XmlTextNode xmi:id="61" sofa="12" begin="0" end="0" parent="51" text="Page Title" captured="false"/>
+    <type9:XmlTextNode xmi:id="71" sofa="12" begin="0" end="0" parent="34" text=" " captured="false"/>
+    <type9:XmlTextNode xmi:id="83" sofa="12" begin="0" end="0" parent="24" text=" " captured="false"/>
+    <type9:XmlTextNode xmi:id="117" sofa="12" begin="1" end="8" parent="107" captured="true"/>
+    <type9:XmlTextNode xmi:id="133" sofa="12" begin="8" end="9" parent="90" captured="true"/>
+    <type9:XmlTextNode xmi:id="150" sofa="12" begin="9" end="39" parent="140" captured="true"/>
+    <type9:XmlTextNode xmi:id="166" sofa="12" begin="39" end="40" parent="90" captured="true"/>
+    <type9:XmlTextNode xmi:id="183" sofa="12" begin="40" end="71" parent="173" captured="true"/>
+    <type9:XmlTextNode xmi:id="199" sofa="12" begin="71" end="72" parent="90" captured="true"/>
+    <type9:XmlTextNode xmi:id="206" sofa="12" begin="72" end="73" parent="90" captured="true"/>
+    <type9:XmlElement xmi:id="24" sofa="12" begin="0" end="73" children="34 83 90" qName="html"/>
+    <type9:XmlElement xmi:id="90" sofa="12" begin="0" end="73" parent="24" children="100 107 133 140 166 173 199 206" qName="body"/>
+    <type9:XmlElement xmi:id="34" sofa="12" begin="0" end="0" parent="24" children="44 51 71" qName="head"/>
+    <type9:XmlElement xmi:id="51" sofa="12" begin="0" end="0" parent="34" children="61" qName="title"/>
+    <type9:XmlElement xmi:id="107" sofa="12" begin="1" end="8" parent="90" children="117" qName="h1"/>
+    <type9:XmlElement xmi:id="140" sofa="12" begin="9" end="39" parent="90" children="150" qName="p"/>
+    <type9:XmlElement xmi:id="173" sofa="12" begin="40" end="71" parent="90" children="183" qName="p"/>
+    <type5:Heading xmi:id="127" sofa="12" begin="1" end="8" divType="h1"/>
+    <type5:Paragraph xmi:id="160" sofa="12" begin="10" end="38" divType="p"/>
+    <type5:Paragraph xmi:id="193" sofa="12" begin="41" end="70" divType="p"/>
+    <type9:XmlDocument xmi:id="19" sofa="12" begin="0" end="73" root="24"/>
+    <cas:Sofa xmi:id="12" sofaNum="1" sofaID="_InitialView" mimeType="text" sofaString=" Heading  This is the first paragraph.   This is the second paragraph.   "/>
+    <cas:View sofa="12" members="1 100 44 61 71 83 117 133 150 166 183 199 206 24 90 34 51 107 140 173 127 160 193 19"/>
+</xmi:XMI>

--- a/dkpro-core-io-xml-asl/pom.xml
+++ b/dkpro-core-io-xml-asl/pom.xml
@@ -83,12 +83,21 @@
       <artifactId>dkpro-core-api-parameter-asl</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-xml-asl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>eu.openminted.share.annotations</groupId>
       <artifactId>omtd-share-annotations-api</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-testing-asl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentReader.java
+++ b/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentReader.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.io.xml;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.fit.descriptor.TypeCapability;
+import org.apache.uima.jcas.JCas;
+import org.dkpro.core.api.io.JCasResourceCollectionReader_ImplBase;
+import org.dkpro.core.api.parameter.MimeTypes;
+import org.dkpro.core.api.resources.CompressionUtils;
+import org.dkpro.core.api.xml.CasXmlHandler;
+import org.xml.sax.InputSource;
+
+import eu.openminted.share.annotations.api.Component;
+import eu.openminted.share.annotations.api.DocumentationResource;
+import eu.openminted.share.annotations.api.Parameters;
+import eu.openminted.share.annotations.api.constants.OperationType;
+
+/**
+ * Simple XML reader which loads all text from the XML file into the CAS document text and generates
+ * XML annotations for all XML elements, attributes and text nodes.
+ * 
+ * @see XmlDocumentWriter
+ */
+@Component(value = OperationType.READER)
+@ResourceMetaData(name = "XML Reader (Simple)")
+@DocumentationResource("${docbase}/format-reference.html#format-${command}")
+@Parameters(
+        exclude = { 
+                XmlReader.PARAM_SOURCE_LOCATION  })
+@MimeTypeCapability({MimeTypes.APPLICATION_XML, MimeTypes.TEXT_XML})
+@TypeCapability(
+        outputs = {
+                "de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData",
+                "org.dkpro.core.api.xml.type.XmlAttribute",
+                "org.dkpro.core.api.xml.type.XmlDocument", 
+                "org.dkpro.core.api.xml.type.XmlElement", 
+                "org.dkpro.core.api.xml.type.XmlNode",
+                "org.dkpro.core.api.xml.type.XmlTextNode" })
+public class XmlDocumentReader
+    extends JCasResourceCollectionReader_ImplBase
+{
+    @Override
+    public void getNext(JCas aJCas) throws IOException, CollectionException
+    {
+        Resource res = nextFile();
+        initCas(aJCas, res);
+
+        try (InputStream is = new BufferedInputStream(
+                CompressionUtils.getInputStream(res.getLocation(), res.getInputStream()))) {
+
+            // Create handler
+            CasXmlHandler handler = new CasXmlHandler(aJCas);
+
+            // Parser XML
+            SAXParserFactory pf = SAXParserFactory.newInstance();
+            SAXParser parser = pf.newSAXParser();
+
+            InputSource source = new InputSource(is);
+            source.setPublicId(res.getLocation());
+            source.setSystemId(res.getLocation());
+            parser.parse(source, handler);
+        }
+        catch (IOException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new CollectionException(e);
+        }
+    }
+}

--- a/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentReader.java
+++ b/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentReader.java
@@ -47,7 +47,7 @@ import eu.openminted.share.annotations.api.constants.OperationType;
  * @see XmlDocumentWriter
  */
 @Component(value = OperationType.READER)
-@ResourceMetaData(name = "XML Reader (Simple)")
+@ResourceMetaData(name = "XML Document Reader")
 @DocumentationResource("${docbase}/format-reference.html#format-${command}")
 @Parameters(
         exclude = { 

--- a/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentWriter.java
+++ b/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentWriter.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.io.xml;
+
+import java.io.OutputStream;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamResult;
+
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.fit.descriptor.TypeCapability;
+import org.apache.uima.jcas.JCas;
+import org.dkpro.core.api.io.JCasFileWriter_ImplBase;
+import org.dkpro.core.api.parameter.ComponentParameters;
+import org.dkpro.core.api.parameter.MimeTypes;
+import org.dkpro.core.api.xml.Cas2SaxEvents;
+
+import eu.openminted.share.annotations.api.DocumentationResource;
+
+/**
+ * Simple XML write takes the XML annotations for elements, attributes and text nodes and renders
+ * them into an XML file.
+ * 
+ * @see XmlDocumentReader
+ */
+@ResourceMetaData(name = "Inline XML Writer")
+@DocumentationResource("${docbase}/format-reference.html#format-${command}")
+@MimeTypeCapability({MimeTypes.APPLICATION_XML, MimeTypes.TEXT_XML})
+@TypeCapability(
+        inputs = {
+                "de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData",
+                "org.dkpro.core.api.xml.type.XmlAttribute",
+                "org.dkpro.core.api.xml.type.XmlDocument", 
+                "org.dkpro.core.api.xml.type.XmlElement", 
+                "org.dkpro.core.api.xml.type.XmlNode",
+                "org.dkpro.core.api.xml.type.XmlTextNode"})
+public class XmlDocumentWriter
+    extends JCasFileWriter_ImplBase
+{
+    /**
+     * Specify the suffix of output files. Default value <code>.txt</code>. If the suffix is not
+     * needed, provide an empty string as value.
+     */
+    public static final String PARAM_FILENAME_EXTENSION = 
+            ComponentParameters.PARAM_FILENAME_EXTENSION;
+    @ConfigurationParameter(name = PARAM_FILENAME_EXTENSION, mandatory = true, defaultValue = ".xml")
+    private String filenameSuffix;
+    
+    /**
+     * Whether to omit the XML preamble.
+     */
+    public static final String PARAM_OMIT_XML_DECLARATION = "omitXmlDeclaration";
+    @ConfigurationParameter(name = PARAM_OMIT_XML_DECLARATION, mandatory = true, defaultValue = "true")
+    private boolean omitXmlDeclaration;
+
+    @Override
+    public void process(JCas aJCas) throws AnalysisEngineProcessException
+    {
+        try (OutputStream docOS = getOutputStream(aJCas, filenameSuffix)) {
+            SAXTransformerFactory tf = (SAXTransformerFactory) TransformerFactory.newInstance();
+            tf.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
+            TransformerHandler th = tf.newTransformerHandler();
+            if (omitXmlDeclaration) {
+                th.getTransformer().setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            }
+            th.setResult(new StreamResult(docOS));
+            
+            Cas2SaxEvents serializer = new Cas2SaxEvents(th);
+            serializer.process(aJCas);
+        }
+        catch (Exception e) {
+            throw new AnalysisEngineProcessException(e);
+        }
+    }
+}

--- a/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentWriter.java
+++ b/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentWriter.java
@@ -44,7 +44,7 @@ import eu.openminted.share.annotations.api.DocumentationResource;
  * 
  * @see XmlDocumentReader
  */
-@ResourceMetaData(name = "Inline XML Writer")
+@ResourceMetaData(name = "XML Document Writer")
 @DocumentationResource("${docbase}/format-reference.html#format-${command}")
 @MimeTypeCapability({MimeTypes.APPLICATION_XML, MimeTypes.TEXT_XML})
 @TypeCapability(

--- a/dkpro-core-io-xml-asl/src/test/java/org/dkpro/core/io/xml/SimpleXmlReaderWriterTest.java
+++ b/dkpro-core-io-xml-asl/src/test/java/org/dkpro/core/io/xml/SimpleXmlReaderWriterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.io.xml;
+
+import static org.dkpro.core.testing.IOTestRunner.testRoundTrip;
+
+import org.dkpro.core.testing.DkproTestContext;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SimpleXmlReaderWriterTest
+{
+    @Test
+    public void testBasic() throws Exception
+    {
+        testRoundTrip(XmlDocumentReader.class, XmlDocumentWriter.class,
+                "xml/basic.xml");
+    }
+
+    @Rule
+    public DkproTestContext testContext = new DkproTestContext();
+}

--- a/dkpro-core-io-xml-asl/src/test/resources/xml/basic.xml
+++ b/dkpro-core-io-xml-asl/src/test/resources/xml/basic.xml
@@ -1,0 +1,3 @@
+<root xmlns="http://defaultNamespace" xmlns:style="http://styleNamespace">
+  This is <style:b a="1" style:b="2">bold</style:b> text.
+</root>


### PR DESCRIPTION
- UIMA types to capture XML structure in the CAS
- Reader/writer for document-oriented XML
- New HtmlDocumentReader capturing the HTML structure in the CAS
- Unit tests