### PR TITLE
Issue/stanford ner train should fail gracefully with empty training collection

### DIFF
--- a/dkpro-core-api-io-asl/pom.xml
+++ b/dkpro-core-api-io-asl/pom.xml
@@ -51,11 +51,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <version>1.7</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
     </dependency>

--- a/dkpro-core-api-io-asl/pom.xml
+++ b/dkpro-core-api-io-asl/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.7</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
     </dependency>

--- a/dkpro-core-api-io-asl/src/main/java/org/dkpro/core/api/io/JCasFileWriter_ImplBase.java
+++ b/dkpro-core-api-io-asl/src/main/java/org/dkpro/core/api/io/JCasFileWriter_ImplBase.java
@@ -31,6 +31,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.fit.component.JCasConsumer_ImplBase;
@@ -307,6 +308,8 @@ public abstract class JCasFileWriter_ImplBase
                 }
             }
 
+            relativeDocumentPath = StringEscapeUtils.escapeHtml4(relativeDocumentPath);
+            
             return relativeDocumentPath;
         }
     }

--- a/dkpro-core-api-io-asl/src/main/java/org/dkpro/core/api/io/JCasFileWriter_ImplBase.java
+++ b/dkpro-core-api-io-asl/src/main/java/org/dkpro/core/api/io/JCasFileWriter_ImplBase.java
@@ -25,13 +25,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.output.CloseShieldOutputStream;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.fit.component.JCasConsumer_ImplBase;
@@ -282,6 +282,13 @@ public abstract class JCasFileWriter_ImplBase
                 relativeDocumentPath = relativeDocumentPath.substring(1);
             }
 
+            try {
+				relativeDocumentPath = URLDecoder.decode(relativeDocumentPath, "UTF-8");
+			} catch (UnsupportedEncodingException e) {
+                // UTF-8 must be supported on all Java platforms per specification. This should
+                // not happen.
+                throw new IllegalStateException(e);
+			}
             return relativeDocumentPath;
         }
         else {
@@ -308,7 +315,13 @@ public abstract class JCasFileWriter_ImplBase
                 }
             }
 
-            relativeDocumentPath = StringEscapeUtils.escapeHtml4(relativeDocumentPath);
+            try {
+				relativeDocumentPath = URLDecoder.decode(relativeDocumentPath, "UTF-8");
+			} catch (UnsupportedEncodingException e) {
+                // UTF-8 must be supported on all Java platforms per specification. This should
+                // not happen.
+                throw new IllegalStateException(e);
+			}
             
             return relativeDocumentPath;
         }

--- a/dkpro-core-api-io-asl/src/test/java/org/dkpro/core/api/io/JCasFileWriter_ImplBaseTest.java
+++ b/dkpro-core-api-io-asl/src/test/java/org/dkpro/core/api/io/JCasFileWriter_ImplBaseTest.java
@@ -35,10 +35,14 @@ import java.util.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
 import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.cas.admin.CASFactory;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
 import org.dkpro.core.api.io.JCasFileWriter_ImplBase;
+import org.junit.Assert;
 import org.junit.Test;
+
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 
 public class JCasFileWriter_ImplBaseTest
 {
@@ -96,6 +100,17 @@ public class JCasFileWriter_ImplBaseTest
         assertEquals(expected, FileUtils.readFileToString(target, "UTF-8"));
     }
 
+    @Test
+    public void test__getRelativePath__FileNameContainsURLEscapedSpaces() throws Exception {
+    	JCas cas = JCasFactory.createJCas();
+        DocumentMetaData meta = DocumentMetaData.create(cas);
+        meta.setDocumentBaseUri("file:/");
+        meta.setDocumentUri("file:/hello%20world");   
+        DummyWriter writer = new DummyWriter();
+        String gotPath = writer.getRelativePath(cas);
+        Assert.assertEquals("", "hello world", gotPath);
+    }
+    
     private List<String> listContents(String aFile)
         throws IOException
     {

--- a/dkpro-core-stanfordnlp-gpl/src/main/java/org/dkpro/core/stanfordnlp/StanfordNamedEntityRecognizerTrainer.java
+++ b/dkpro-core-stanfordnlp-gpl/src/main/java/org/dkpro/core/stanfordnlp/StanfordNamedEntityRecognizerTrainer.java
@@ -129,7 +129,7 @@ public class StanfordNamedEntityRecognizerTrainer
 
     private File tempData;
     private PrintWriter out;
-
+    
     @Override
     public void initialize(UimaContext aContext)
             throws ResourceInitializationException {
@@ -233,6 +233,10 @@ public class StanfordNamedEntityRecognizerTrainer
     @Override
     public void collectionProcessComplete()
             throws AnalysisEngineProcessException {
+    	if (tempData == null) {
+    		throw new RuntimeException("No training data was received by the trainer");
+    	}
+    	
         IOUtils.closeQuietly(out);
 
         // Load user-provided configuration

--- a/dkpro-core-stanfordnlp-gpl/src/test/java/org/dkpro/core/stanfordnlp/StanfordNamedEntityRecognizerTrainerTest.java
+++ b/dkpro-core-stanfordnlp-gpl/src/test/java/org/dkpro/core/stanfordnlp/StanfordNamedEntityRecognizerTrainerTest.java
@@ -25,10 +25,14 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.collection.CollectionReader;
 import org.apache.uima.collection.CollectionReaderDescription;
+import org.apache.uima.fit.factory.CollectionReaderFactory;
 import org.apache.uima.fit.factory.ConfigurationParameterFactory;
 import org.apache.uima.fit.pipeline.SimplePipeline;
 import org.dkpro.core.api.datasets.Dataset;
@@ -41,6 +45,7 @@ import org.dkpro.core.io.conll.Conll2002Reader;
 import org.dkpro.core.io.conll.Conll2002Reader.ColumnSeparators;
 import org.dkpro.core.io.conll.Conll2002Writer;
 import org.dkpro.core.testing.DkproTestContext;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -130,6 +135,42 @@ public class StanfordNamedEntityRecognizerTrainerTest
         assertEquals(0.408708, results.getRecall(), 0.01);
     }
 
+    @Test
+    public void test__EmptyDataset__ShouldRaiseExceptionWithHelpfulMessage()
+        throws Exception
+    {
+        Path emptyDir = Files.createTempDirectory("empty_dir");
+        File targetFolder = testContext.getTestOutputFolder();
+
+        File model = new File(targetFolder, "ner-model.ser.gz");
+
+        File properties = new File("ner/train-english.props");
+
+        CollectionReaderDescription trainReader = createReaderDescription(Conll2002Reader.class,
+                Conll2002Reader.PARAM_SOURCE_LOCATION, emptyDir.toAbsolutePath().toString(),
+                Conll2002Reader.PARAM_PATTERNS, "*.txt",
+                Conll2002Reader.PARAM_LANGUAGE, "en",
+                Conll2002Reader.PARAM_COLUMN_SEPARATOR, ColumnSeparators.TAB.getName(),
+                Conll2002Reader.PARAM_HAS_TOKEN_NUMBER, true, 
+                Conll2002Reader.PARAM_HAS_HEADER, true, 
+                Conll2002Reader.PARAM_HAS_EMBEDDED_NAMED_ENTITY, true);
+
+        AnalysisEngineDescription trainer = createEngineDescription(
+                StanfordNamedEntityRecognizerTrainer.class,
+                StanfordNamedEntityRecognizerTrainer.PARAM_TARGET_LOCATION, model,
+                StanfordNamedEntityRecognizerTrainer.PARAM_PROPERTIES_LOCATION, properties,
+                StanfordNamedEntityRecognizerTrainer.PARAM_LABEL_SET, "noprefix",
+                StanfordNamedEntityRecognizerTrainer.PARAM_RETAIN_CLASS, true);
+
+        try {
+        	SimplePipeline.runPipeline(trainReader, trainer);
+        	Assert.fail("Feeding an empty collection of documents to the trainer should have raised an exception");
+        } catch (RuntimeException e) {
+        	Assert.assertEquals("The raised exception did not have the right message", 
+        			"No training data was received by the trainer", e.getMessage());
+        }
+    }    
+    
     @Before
     public void setup()
         throws IOException


### PR DESCRIPTION
This pull request deals with issue #1395: "null pointer exception in StanfordNamedEntityRecognizerTrainer"

I am still green w.r.t. issueing pull requests so I am not sure if I did this right. It seems like the branch of this pull request might be based on the branch from my earlier pull request (#1392) and I suspect that this is not a good idea. If this is wrong, please let me know and any help on how to address it would be appreciated. I have been using git for 4 years now, but I never use remote branches so I am not that familiar with how they work and how to set them up. Thank you for your patience.