### PR TITLE
 #1404 - JDK 12 processes XML differently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ libudpipe_java.dylib
 .DS_Store
 .checkstyle
 learning.log
+.factorypath

--- a/dkpro-core-asl/pom.xml
+++ b/dkpro-core-asl/pom.xml
@@ -779,6 +779,7 @@
                 <configuration>
                   <consoleOutput>true</consoleOutput>
                   <excludes>
+                    <exclude>.factorypath</exclude>
                     <exclude>.activate-run-jcasgen</exclude>
                     <exclude>.gitignore</exclude>
                     <exclude>.checkstyle</exclude>

--- a/dkpro-core-io-html-asl/pom.xml
+++ b/dkpro-core-io-html-asl/pom.xml
@@ -90,6 +90,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-testing-asl</artifactId>
       <scope>test</scope>

--- a/dkpro-core-io-html-asl/src/main/java/org/dkpro/core/io/html/HtmlDocumentReader.java
+++ b/dkpro-core-io-html-asl/src/main/java/org/dkpro/core/io/html/HtmlDocumentReader.java
@@ -94,6 +94,13 @@ public class HtmlDocumentReader
     @ConfigurationParameter(name = PARAM_SOURCE_ENCODING, mandatory = true, 
             defaultValue = ComponentParameters.DEFAULT_ENCODING)
     private String sourceEncoding;
+    
+    /**
+     * Normalize whitespace.
+     */
+    public static final String PARAM_NORMALIZE_WHITESPACE = "normalizeWhitespace";
+    @ConfigurationParameter(name = PARAM_NORMALIZE_WHITESPACE, mandatory = true, defaultValue = "true")
+    private boolean normalizeWhitespace;
 
     private Map<String, Integer> mappings = new HashMap<>();
     
@@ -151,7 +158,12 @@ public class HtmlDocumentReader
                     else if (node instanceof TextNode) {
                         TextNode textNode = (TextNode) node;
                         StringBuilder buffer = new StringBuilder();
-                        appendNormalisedText(buffer, textNode);
+                        if (normalizeWhitespace) {
+                            appendNormalisedText(buffer, textNode);
+                        }
+                        else {
+                            buffer.append(textNode.getWholeText());
+                        }
                         char[] text = buffer.toString().toCharArray();
                         handler.characters(text, 0, text.length);
                     }

--- a/dkpro-core-io-html-asl/src/test/java/org/dkpro/core/io/html/HtmlDocumentReaderTest.java
+++ b/dkpro-core-io-html-asl/src/test/java/org/dkpro/core/io/html/HtmlDocumentReaderTest.java
@@ -24,14 +24,21 @@ import static org.apache.uima.fit.util.JCasUtil.select;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dkpro.core.testing.IOTestRunner.testOneWay;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.uima.collection.CollectionReader;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
+import org.custommonkey.xmlunit.XMLAssert;
 import org.dkpro.core.io.xmi.XmiWriter;
 import org.dkpro.core.io.xml.XmlDocumentWriter;
 import org.dkpro.core.testing.DkproTestContext;
+import org.dkpro.core.testing.TestOptions;
 import org.junit.Rule;
 import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Heading;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph;
@@ -68,10 +75,12 @@ public class HtmlDocumentReaderTest
     {
         testOneWay(
                 createReaderDescription(HtmlDocumentReader.class,
-                        HtmlDocumentReader.PARAM_LANGUAGE, "en"),
+                        HtmlDocumentReader.PARAM_LANGUAGE, "en",
+                        HtmlDocumentReader.PARAM_NORMALIZE_WHITESPACE, false),
                 createEngineDescription(XmlDocumentWriter.class),
                 "html/test-document.xml", 
-                "html/test.html");
+                "html/test.html",
+                new TestOptions().resultAssertor(this::assertXmlEquals));
     }
     
     @Test
@@ -122,6 +131,17 @@ public class HtmlDocumentReaderTest
                 "html/test-with-head.html");
     }
 
+    private void assertXmlEquals(File expected, File actual)
+    {
+        try {
+            XMLAssert.assertXMLEqual(
+                    new InputSource(expected.getPath()),
+                    new InputSource(actual.getPath()));
+        }
+        catch (SAXException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
     @Rule
     public DkproTestContext testContext = new DkproTestContext();
 }

--- a/dkpro-core-io-html-asl/src/test/resources/html/test-document.xml
+++ b/dkpro-core-io-html-asl/src/test/resources/html/test-document.xml
@@ -1,10 +1,10 @@
-<html>
-<head>
-<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-</head>
-<body> 
-<h1>Heading</h1> 
-<p> This is the first paragraph. </p> 
-<p> This is the second paragraph. </p>  
-</body>
-</html>
+<html><head/><body>
+    <h1>Heading</h1>
+    <p>
+      This is the first paragraph.
+    </p>
+    <p>
+      This is the second paragraph.
+    </p>
+  
+</body></html>

--- a/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentWriter.java
+++ b/dkpro-core-io-xml-asl/src/main/java/org/dkpro/core/io/xml/XmlDocumentWriter.java
@@ -17,9 +17,12 @@
  */
 package org.dkpro.core.io.xml;
 
+import static javax.xml.transform.OutputKeys.INDENT;
+import static javax.xml.transform.OutputKeys.METHOD;
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+
 import java.io.OutputStream;
 
-import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
@@ -74,6 +77,20 @@ public class XmlDocumentWriter
     @ConfigurationParameter(name = PARAM_OMIT_XML_DECLARATION, mandatory = true, defaultValue = "true")
     private boolean omitXmlDeclaration;
 
+    /**
+     * Output method.
+     */
+    public static final String PARAM_OUTPUT_METHOD = "outputMethod";
+    @ConfigurationParameter(name = PARAM_OUTPUT_METHOD, mandatory = true, defaultValue = "xml")
+    private String outputMethod;
+
+    /**
+     * Indent output .
+     */
+    public static final String PARAM_INDENT = "indent";
+    @ConfigurationParameter(name = PARAM_INDENT, mandatory = true, defaultValue = "false")
+    private boolean indent;
+
     @Override
     public void process(JCas aJCas) throws AnalysisEngineProcessException
     {
@@ -82,8 +99,10 @@ public class XmlDocumentWriter
             tf.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
             TransformerHandler th = tf.newTransformerHandler();
             if (omitXmlDeclaration) {
-                th.getTransformer().setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+                th.getTransformer().setOutputProperty(OMIT_XML_DECLARATION, "yes");
             }
+            th.getTransformer().setOutputProperty(METHOD, outputMethod);
+            th.getTransformer().setOutputProperty(INDENT, indent ? "yes" : "no");
             th.setResult(new StreamResult(docOS));
             
             Cas2SaxEvents serializer = new Cas2SaxEvents(th);


### PR DESCRIPTION
- Added option to enable/disable whitespace normalization in HtmlDocumentReader
- Disable whitespace normalization in the HtmlDocumentReader which writes the document out as XML
- Adjusted reference data for this test
- Added parameters to XmlDocumentWriter to control indentation (off by default) and output method (XML by default)