### PR TITLE
#1434 - WebAnnoTsv3XWriter does not support elevated types

### DIFF
--- a/dkpro-core-io-cermine-gpl/pom.xml
+++ b/dkpro-core-io-cermine-gpl/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2007-2018
+    Copyright 2007-2019
     Ubiquitous Knowledge Processing (UKP) Lab
     Technische Universität Darmstadt
 

--- a/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/Tsv3XCasDocumentBuilder.java
+++ b/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/Tsv3XCasDocumentBuilder.java
@@ -112,12 +112,17 @@ public class Tsv3XCasDocumentBuilder
         // Scan all annotations of the types defined in the schema and use them to set up sub-token
         // units.
         for (Type type : aSchema.getUimaTypes()) {
+            if (aSchema.getIgnoredTypes().contains(type)) {
+                continue;
+            }
+            
             LayerType layerType = aSchema.getLayerType(type);
             
             boolean addDisambiguationIdIfStacked = SPAN.equals(layerType);
             
             for (AnnotationFS annotation : CasUtil.select(aJCas.getCas(), type)) {
-                doc.activateType(annotation.getType());
+                // Mind that we might actually get an annotation here which is a subtype of `type`!
+                doc.activateType(type);
                 
                 // Get the relevant begin and end offsets for the current annotation
                 int begin = annotation.getBegin();
@@ -139,8 +144,12 @@ public class Tsv3XCasDocumentBuilder
                 // token before the start token using floorEntry(end) - so let's try to correct this
                 if (
                         // found begin token but found the wrong one
-                        (beginTokenEntry != null && beginTokenEntry.getValue().getEnd() < begin) ||
-                        // didn't find end begin because annotation starts before the first token
+                        (
+                                beginTokenEntry != null && 
+                                beginTokenEntry.getValue().getEnd() < begin && 
+                                tokenEndIndex.higherEntry(begin) != null
+                        ) ||
+                        // didn't find begin token because annotation starts before the first token
                         beginTokenEntry == null
                 ) {
                     beginTokenEntry = tokenEndIndex.higherEntry(begin);
@@ -158,7 +167,11 @@ public class Tsv3XCasDocumentBuilder
                 // token after the end token using ceilingEntry(end) - so let's try to correct this
                 if (
                         // found end token but found the wrong one
-                        (endTokenEntry != null && endTokenEntry.getValue().getBegin() > end) ||
+                        (
+                                endTokenEntry != null && 
+                                endTokenEntry.getValue().getBegin() > end &&
+                                tokenEndIndex.lowerEntry(end) != null
+                        ) ||
                         // didn't find end token because annotation ends beyond the last token
                         endTokenEntry == null
                 ) {
@@ -198,10 +211,20 @@ public class Tsv3XCasDocumentBuilder
                     }
                 }
                 else if (zeroWitdh) {
-                    TsvSubToken t = beginToken.createSubToken(begin, min(beginToken.getEnd(), end));
+                    // If the zero-width annotation happens in the space between tokens or after
+                    // the last token, we move it to the end of the closest preceding token in order
+                    // not to have to drop it entirely.
+                    int position = min(beginToken.getEnd(), end);
+                    // ... or if the annotation is before the first token, then we move it to the
+                    // begin of the first token 
+                    if (position < beginToken.getBegin()) {
+                        position = beginToken.getBegin();
+                    }
+                    TsvSubToken t = beginToken.createSubToken(position, position);
                     doc.mapFS2Unit(annotation, t);
                     t.addUimaAnnotation(annotation, addDisambiguationIdIfStacked);
-                } else {
+                }
+                else {
                     // Annotation covers only suffix of the begin token - we need to create a 
                     // suffix sub-token unit on the begin token. The new sub-token defines the ID of
                     // the annotation.
@@ -287,6 +310,16 @@ public class Tsv3XCasDocumentBuilder
         for (TsvColumn col : aUnit.getDocument().getSchema().getColumns()) {
             List<AnnotationFS> annotationsForColumn = aUnit.getAnnotationsForColumn(col);
             if (!annotationsForColumn.isEmpty()) {
+//                if (SPAN.equals(col.layerType) && SLOT_TARGET.equals(col.featureType)) {
+//                    for (AnnotationFS aFS : annotationsForColumn) {
+//                        FeatureStructure[] links = getFeature(aFS, col.uimaFeature,
+//                                FeatureStructure[].class);
+//                        if (links != null && links.length > 0) {
+//                        }
+//                    }
+//                }
+                
+                
                 if (!PLACEHOLDER.equals(col.featureType)) {
                     aUnit.getDocument().activateColumn(col);
                 }
@@ -316,7 +349,8 @@ public class Tsv3XCasDocumentBuilder
                                 .getType(POS.class.getName()));
                     }
                     else {
-                        col.setTargetTypeHint(target.getType());
+                        TsvSchema schema = aUnit.getDocument().getSchema();
+                        col.setTargetTypeHint(schema.getEffectiveType(target));
                     }
                 }
             }

--- a/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/Tsv3XSerializer.java
+++ b/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/Tsv3XSerializer.java
@@ -45,7 +45,6 @@ import static org.dkpro.core.io.webanno.tsv.internal.tsv3x.model.TsvSchema.FEAT_
 
 import java.io.PrintWriter;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;

--- a/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/model/TsvSchema.java
+++ b/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/model/TsvSchema.java
@@ -29,13 +29,17 @@ import static org.dkpro.core.io.webanno.tsv.internal.tsv3x.model.LayerType.SPAN;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
+import org.apache.uima.cas.TypeSystem;
 
 public class TsvSchema
 {
@@ -55,6 +59,18 @@ public class TsvSchema
     
     private List<TsvColumn> columns = new ArrayList<>();
     private Set<Type> chainHeadTypes = new HashSet<>();
+    private Set<Type> ignoredTypes = new HashSet<>();
+    private Map<Type, Type> effectiveTypes = new HashMap<>();
+    
+    public void ignoreType(Type aType)
+    {
+        ignoredTypes.add(aType);
+    }
+    
+    public Set<Type> getIgnoredTypes()
+    {
+        return ignoredTypes;
+    }
 
     public void addColumn(TsvColumn aColumn)
     {
@@ -186,5 +202,24 @@ public class TsvSchema
     public Set<Type> getChainHeadTypes()
     {
         return chainHeadTypes;
+    }
+
+    /**
+     * Locate a type which is known to the schema and which is equal to or a super-type of the type
+     * of the given {@link FeatureStructure}. If no such type is found, the actual type is returned.
+     * The results are cached for faster lookups.
+     * 
+     * @param aFS
+     *            a feature structure.
+     * @return the effective type.
+     */
+    public Type getEffectiveType(FeatureStructure aFS)
+    {
+        TypeSystem typeSystem = aFS.getCAS().getTypeSystem();
+        
+        return effectiveTypes.computeIfAbsent(aFS.getType(), type -> getUimaTypes().stream()
+                .filter(t -> typeSystem.subsumes(t, type))
+                .findFirst()
+                .orElse(aFS.getType()));
     }
 }

--- a/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/model/TsvUnit.java
+++ b/dkpro-core-io-webanno-asl/src/main/java/org/dkpro/core/io/webanno/tsv/internal/tsv3x/model/TsvUnit.java
@@ -98,9 +98,10 @@ public abstract class TsvUnit
      */
     public void addUimaAnnotation(AnnotationFS aFS, boolean aAddDisambiguationIfStacked)
     {
-        uimaAnnotations.putIfAbsent(aFS.getType(), new ArrayList<>());
+        Type effectiveType = getDocument().getSchema().getEffectiveType(aFS);
+        uimaAnnotations.putIfAbsent(effectiveType, new ArrayList<>());
         
-        List<AnnotationFS> annotations = uimaAnnotations.get(aFS.getType());
+        List<AnnotationFS> annotations = uimaAnnotations.get(effectiveType);
         
         // If we already have annotations of this type, then we need to add disambiguation IDs.
         boolean alreadyHaveAnnotationsOfSameType = !annotations.isEmpty();

--- a/dkpro-core-io-webanno-asl/src/test/resources/tsv3-suite/testElevatedType/reference.tsv
+++ b/dkpro-core-io-webanno-asl/src/test/resources/tsv3-suite/testElevatedType/reference.tsv
@@ -1,0 +1,6 @@
+#FORMAT=WebAnno TSV 3.2
+#T_SP=de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS|PosValue|coarseValue
+
+
+#Text=John
+1-1	0-4	John	NN	NOUN	

--- a/dkpro-core-io-webanno-asl/src/test/resources/tsv3-suite/testElevatedType/reference.xmi
+++ b/dkpro-core-io-webanno-asl/src/test/resources/tsv3-suite/testElevatedType/reference.xmi
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?><xmi:XMI xmlns:pos="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos.ecore" xmlns:tcas="http:///uima/tcas.ecore" xmlns:xmi="http://www.omg.org/XMI" xmlns:cas="http:///uima/cas.ecore" xmlns:tweet="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/tweet.ecore" xmlns:morph="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/morph.ecore" xmlns:dependency="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency.ecore" xmlns:type6="http:///de/tudarmstadt/ukp/dkpro/core/api/semantics/type.ecore" xmlns:type="http:///de/tudarmstadt/ukp/dkpro/core/api/anomaly/type.ecore" xmlns:type7="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type.ecore" xmlns:type3="http:///de/tudarmstadt/ukp/dkpro/core/api/metadata/type.ecore" xmlns:type4="http:///de/tudarmstadt/ukp/dkpro/core/api/ner/type.ecore" xmlns:type5="http:///de/tudarmstadt/ukp/dkpro/core/api/segmentation/type.ecore" xmlns:type2="http:///de/tudarmstadt/ukp/dkpro/core/api/coref/type.ecore" xmlns:constituent="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent.ecore" xmlns:chunk="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/chunk.ecore" xmi:version="2.0">
+    <cas:NULL xmi:id="0"/>
+    <type3:DocumentMetaData xmi:id="1" sofa="2" begin="0" end="4" documentId="doc" isLastSegment="false"/>
+    <pos:POS_NOUN xmi:id="3" sofa="2" begin="0" end="4" PosValue="NN" coarseValue="NOUN"/>
+    <type5:Token xmi:id="4" sofa="2" begin="0" end="4" pos="3" order="0"/>
+    <type5:Sentence xmi:id="5" sofa="2" begin="0" end="4"/>
+    <cas:Sofa xmi:id="2" sofaNum="1" sofaID="_InitialView" mimeType="text" sofaString="John"/>
+    <cas:View sofa="2" members="1 3 4 5"/>
+</xmi:XMI>


### PR DESCRIPTION
- Export elevated types as whichever of their supertypes is actually part of the TsvSchema (i.e. a subtype of Annotation)
- Added unit test