### PR TITLE
#1465 - Drop missing IXA models for OpenNLP

### DIFF
--- a/dkpro-core-opennlp-asl/src/scripts/build.xml
+++ b/dkpro-core-opennlp-asl/src/scripts/build.xml
@@ -17,7 +17,7 @@
 -->
 <project basedir="../.." default="separate-jars">
 	<import>
-		<url url="https://raw.githubusercontent.com/dkpro/resource-packager/0.6.0/ant-macros.xml"/>
+		<url url="https://raw.githubusercontent.com/dkpro/resource-packager/0.8.0/ant-macros.xml"/>
 	</import>
 
 	<!-- 
@@ -146,7 +146,7 @@
 		<antcall target="de-tagger-maxent"/>
 		<antcall target="de-tagger-perceptron"/>
 		<antcall target="de-chunker-default"/>
-        <antcall target="de-ner-nemgp"/>
+		<antcall target="de-ner-nemgp"/>
 	</target>
 	
 	<target name="de-sentence-maxent">
@@ -299,7 +299,7 @@
 
 	<target name="en">
 		<antcall target="en-chunker-default"/>
-        <antcall target="en-chunker-perceptron-ixa"/>
+		<antcall target="en-chunker-perceptron-ixa"/>
 		<antcall target="en-ner-date"/>
 		<antcall target="en-ner-location"/>
 		<antcall target="en-ner-money"/>
@@ -308,11 +308,10 @@
 		<antcall target="en-ner-person"/>
 		<antcall target="en-ner-time"/>
 		<antcall target="en-parser-chunking"/>
-        <antcall target="en-parser-chunking-ixa"/>
+		<antcall target="en-parser-chunking-ixa"/>
 		<antcall target="en-sentence-maxent"/>
 		<antcall target="en-tagger-maxent"/>
 		<antcall target="en-tagger-perceptron"/>
-		<antcall target="en-tagger-perceptron-ixa"/>
 		<antcall target="en-token-maxent"/>
 	</target>
 
@@ -387,7 +386,7 @@
 			</metadata>
 		</install-stub-and-upstream-file>
 	</target>
-
+    
 	<target name="en-tagger-perceptron">
 		<mkdir dir="target/download"/>
 		<!-- FILE: models-1.5/en-pos-perceptron.bin - - - - - - - - - - - - - - - - - - - - - - - -
@@ -653,37 +652,6 @@
 		</install-stub-and-upstream-file>
 	</target>
 
-	<target name="en-tagger-perceptron-ixa" depends="download-ixa-pos-resources">
-		<mkdir dir="target/download"/>
-		<!-- FILE: en-pos-perceptron-c0-b3-dev.bin - - - - - - - - - - - - - - - - - - - - - - - - -
-		  - 2013-11-15 | now        | bf0545ff008f211bb282ce08f6977872
-		  -->
-    	<install-stub-and-upstream-file 
-    		file="target/download/ixa-pos-resources/en-pos-perceptron-c0-b3-dev.bin" 
-    		md5="bf0545ff008f211bb282ce08f6977872"
-    		groupId="de.tudarmstadt.ukp.dkpro.core" 
-    		artifactIdBase="de.tudarmstadt.ukp.dkpro.core.opennlp"
-    		upstreamVersion="20131115"
-    		metaDataVersion="1"
-    		tool="tagger" 
-    		language="en" 
-    		variant="perceptron-ixa" 
-    		extension="bin">
-			<metadata>
-				<entry key="DC.title" value="en-pos-perceptron-c0-b3-dev.bin"/>
-				<entry key="DC.creator" value="Rodrigo Agerri"/>
-				<entry key="DC.identifier" value="http://ixa2.si.ehu.es/ixa-pipes/models/pos-resources.tgz#en-pos-perceptron-c0-b3-dev.bin"/>
-	    		<entry key="pos.tagset" value="ptb"/>
-				<!--
-			      - Contains 78 tags because it includes multitags such as "IN|RB" or "RB|IN", looks
-		          - otherwise like PTB tagset. We tell OpenNlpPosTagger to keep only the first
-		          - tag.
-				  -->
-				<entry key="pos.tagset.tagSplitPattern" value="\|"/>
-			</metadata>
-		</install-stub-and-upstream-file>
-	</target>
-
     <target name="en-parser-chunking-ixa" depends="download-ixa-parser-resources">
         <!-- FILE: en-parser-chunking.bin - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           - 2014-04-26 | now        | 47c1b3f4dd7d08e992abdca4e16638ce
@@ -716,12 +684,10 @@
 		<antcall target="es-ner-organization"/>
 		<antcall target="es-ner-person"/>
 		<antcall target="es-tagger-maxent"/>
-		<antcall target="es-tagger-maxent-ixa"/>
 		<antcall target="es-tagger-maxent-universal"/>
 		<antcall target="es-tagger-perceptron"/>
-		<antcall target="es-tagger-perceptron-ixa"/>
 		<antcall target="es-tagger-perceptron-universal"/>
-        <antcall target="es-parser-chunking-ixa"/>
+		<antcall target="es-parser-chunking-ixa"/>
 	</target>
 
 	<target name="es-tagger-maxent">
@@ -914,54 +880,6 @@
 		</install-stub-and-upstream-file>
 	</target>
 
-	<target name="es-tagger-maxent-ixa" depends="download-ixa-pos-resources">
-		<!-- FILE: es-pos-maxent-700-c0-b3.bin - - - - - - - - - - - - - - - - - - - - - - - - - - -
-		  - 2014-04-25 | now        | 6893840d709c581e378750b53f24531b
-		  -->
-    	<install-stub-and-upstream-file 
-    		file="target/download/ixa-pos-resources/es-pos-maxent-700-c0-b3.bin" 
-    		md5="6893840d709c581e378750b53f24531b"
-    		groupId="de.tudarmstadt.ukp.dkpro.core" 
-    		artifactIdBase="de.tudarmstadt.ukp.dkpro.core.opennlp"
-    		upstreamVersion="20140425"
-    		metaDataVersion="1"
-    		tool="tagger" 
-    		language="es" 
-    		variant="maxent-ixa" 
-    		extension="bin">
-			<metadata>
-				<entry key="DC.title" value="es-pos-maxent-700-c0-b3.bin"/>
-				<entry key="DC.creator" value="Rodrigo Agerri"/>
-				<entry key="DC.identifier" value="http://ixa2.si.ehu.es/ixa-pipes/models/pos-resources.tgz#es-pos-maxent-700-c0-b3.bin"/>
-	    		<entry key="pos.tagset" value="ancora-ixa"/>
-			</metadata>
-		</install-stub-and-upstream-file>
-	</target>
-
-	<target name="es-tagger-perceptron-ixa" depends="download-ixa-pos-resources">
-		<!-- FILE: es-pos-perceptron-c0-b3.bin - - - - - - - - - - - - - - - - - - - - - - - - - - -
-		  - 2013-11-15 | now        | 148d7ff4c56c89624e6050fe608f6d8a
-		  -->
-    	<install-stub-and-upstream-file 
-    		file="target/download/ixa-pos-resources/es-pos-perceptron-c0-b3.bin" 
-    		md5="148d7ff4c56c89624e6050fe608f6d8a"
-    		groupId="de.tudarmstadt.ukp.dkpro.core" 
-    		artifactIdBase="de.tudarmstadt.ukp.dkpro.core.opennlp"
-    		upstreamVersion="20131115"
-    		metaDataVersion="1"
-    		tool="tagger" 
-    		language="es" 
-    		variant="perceptron-ixa" 
-    		extension="bin">
-			<metadata>
-				<entry key="DC.title" value="es-pos-perceptron-c0-b3.bin"/>
-				<entry key="DC.creator" value="Rodrigo Agerri"/>
-				<entry key="DC.identifier" value="http://ixa2.si.ehu.es/ixa-pipes/models/pos-resources.tgz#es-pos-perceptron-c0-b3.bin"/>
-	    		<entry key="pos.tagset" value="ancora-ixa"/>
-			</metadata>
-		</install-stub-and-upstream-file>
-	</target>
-	
     <target name="es-parser-chunking-ixa" depends="download-ixa-parser-resources">
         <!-- FILE: es-parser-chunking.bin - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           - 2014-04-26 | now        | 42589e408c5ed89beaf8107662bc751c
@@ -1010,7 +928,7 @@
             </metadata>
         </install-stub-and-upstream-file>
     </target>
-    
+
 	<target name="it">
 		<antcall target="it-sentence-maxent"/>
 		<antcall target="it-tagger-maxent"/>
@@ -1651,32 +1569,6 @@
 	    		<entry key="pos.tagset" value="talbanken05"/>
 			</metadata>
 		</install-stub-and-upstream-file>
-	</target>
-	
-	<target name="-check-download-ixa-pos-resources">
-		<available 
-			property="download-ixa-pos-resources.DONE" 
-			file="target/download/ixa-pos-resources/DONE"/>
-	</target>
-
-	<target name="download-ixa-pos-resources" depends="-check-download-ixa-pos-resources" unless="download-ixa-pos-resources.DONE">
-		<mkdir dir="target/download/ixa-pos-resources"/>
-    	<get 
-    		src="http://ixa2.si.ehu.es/ixa-pipes/models/pos-resources.tgz" 
-    		dest="target/download/ixa-pos-resources/pos-resources.tgz" 
-    		skipexisting="true"/>
-		<untar 
-			src="target/download/ixa-pos-resources/pos-resources.tgz" 
-			dest="target/download/ixa-pos-resources"
-            compression="gzip">
-    		<patternset>
-    			<include name="**/*.bin"/>		
-			</patternset>
-    		<chainedmapper>
-	    		<mapper type="flatten"/>
-    		</chainedmapper>
-    	</untar>
-		<touch file="target/download/ixa-pos-resources/DONE"/>
 	</target>
 	
     <target name="-check-download-ixa-parser-resources">

--- a/dkpro-core-opennlp-asl/src/test/java/org/dkpro/core/opennlp/OpenNlpPosTaggerBulkTest.java
+++ b/dkpro-core-opennlp-asl/src/test/java/org/dkpro/core/opennlp/OpenNlpPosTaggerBulkTest.java
@@ -132,7 +132,7 @@ public class OpenNlpPosTaggerBulkTest
                     new String[] { "pron-det", "v-fin", "artm", "nm", "." },
                     new String[] { "POS", "POS", "POS", "POS", "POS" } } };
     
-    @Parameters(name = "{index}: {0}-{1} {2}: [{4}]")
+    @Parameters
     public static Collection<Object[]> data() {
         return asList(DATA);
     }

--- a/dkpro-core-opennlp-asl/src/test/java/org/dkpro/core/opennlp/OpenNlpPosTaggerBulkTest.java
+++ b/dkpro-core-opennlp-asl/src/test/java/org/dkpro/core/opennlp/OpenNlpPosTaggerBulkTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.opennlp;
+
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.util.JCasUtil.select;
+import static org.dkpro.core.testing.AssertAnnotations.assertPOS;
+import static org.dkpro.core.testing.AssertAnnotations.assertTagset;
+import static org.dkpro.core.testing.AssumeResource.assumeResource;
+
+import java.util.Collection;
+
+import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.jcas.JCas;
+import org.dkpro.core.testing.DkproTestContext;
+import org.dkpro.core.testing.TestRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
+
+@RunWith(Parameterized.class)
+public class OpenNlpPosTaggerBulkTest
+{
+    private static final String NO_TAGSET_CHECK = null;
+    
+    private static final String[] TAGSET_BOSQUE = { "?", "adj", "adv", "art", "conj-c", "conj-s",
+            "ec", "in", "n", "num", "pp", "pron-det", "pron-indp", "pron-pers", "prop", "prp",
+            "punc", "v-fin", "v-ger", "v-inf", "v-pcp", "vp" };
+    
+    private static final Object[][] DATA = {
+            { "en", null, NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "This is a test .", 
+                    new String[] { "DT", "VBZ", "DT", "NN", "." },
+                    new String[] { "POS_DET", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "en", null, NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "A neural net .", 
+                    new String[] { "DT", "JJ", "NN", "." },
+                    new String[] { "POS_DET", "POS_ADJ", "POS_NOUN", "POS_PUNCT" } },
+            { "en", null, NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "John is purchasing oranges .",
+                    new String[] { "NNP", "VBZ", "VBG", "NNS", "." },
+                    new String[] { "POS_PROPN", "POS_VERB", "POS_VERB", "POS_NOUN", "POS_PUNCT" } },
+            // This is WRONG tagging. "jumps" is tagged as "NNS"
+            { "en", "maxent", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "The quick brown fox jumps over the lazy dog .",
+                    new String[] { "DT", "JJ", "JJ", "NN", "NNS", "IN", "DT", "JJ", "NN", "." },
+                    new String[] { "POS_DET", "POS_ADJ", "POS_ADJ", "POS_NOUN", "POS_NOUN",
+                            "POS_ADP", "POS_DET", "POS_ADJ", "POS_NOUN", "POS_PUNCT" } },
+            { "en", "perceptron", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "The quick brown fox jumps over the lazy dog .",
+                    new String[] { "DT", "JJ", "JJ", "NN", "NNS", "IN", "DT", "JJ", "NN", "." },
+                    new String[] { "POS_DET", "POS_ADJ", "POS_ADJ", "POS_NOUN", "POS_NOUN",
+                            "POS_ADP", "POS_DET", "POS_ADJ", "POS_NOUN", "POS_PUNCT" } },
+            { "de", null, NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Das ist ein Test .", 
+                    new String[] { "PDS", "VAFIN", "ART", "NN", "$." },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "de", "maxent", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Das ist ein Test .",
+                    new String[] { "PDS", "VAFIN", "ART", "NN", "$." },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "de", "perceptron", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Das ist ein Test .",
+                    new String[] { "PDS", "VAFIN", "ART", "NN", "$." },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "it", null, NO_TAGSET_CHECK, NO_TAGSET_CHECK, 
+                    "Questo è un test .", 
+                    new String[] { "PD", "Vip3", "RI", "Sn", "FS" },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "it", "perceptron", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Questo è un test .",
+                    new String[] { "PD", "Vip3", "RI", "Sn", "FS" },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "es", "maxent", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Esta es una prueba .",
+                    new String[] { "PD", "VSI", "DI", "NC", "Fp" },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "es", "maxent-ixa", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Esta es una prueba .",
+                    new String[] { "PD0FS000", "VSIP3S0", "DI0FS0", "NCFS000", "Fp" },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "es", "perceptron-ixa", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Esta es una prueba .",
+                    new String[] { "PD0FS000", "VSIP3S0", "DI0FS0", "NCFS000", "Fp" },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "sv", "maxent", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Detta är ett test .", 
+                    new String[] { "PO", "AV", "EN", "NN", "IP" },
+                    new String[] { "POS", "POS", "POS", "POS", "POS" } },
+            { "pt", null, "bosque", TAGSET_BOSQUE,
+                    "Este é um teste .", 
+                    new String[] { "pron-det", "v-fin", "art", "n", "punc" },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "pt", "maxent", "bosque", TAGSET_BOSQUE,
+                    "Este é um teste .", 
+                    new String[] { "pron-det", "v-fin", "art", "n", "punc" },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "pt", "perceptron", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Este é um teste .",
+                    new String[] { "pron-det", "v-fin", "art", "n", "punc" },
+                    new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" } },
+            { "pt", "mm-maxent", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Este é um teste .",
+                    new String[] { "PROSUB", "V", "ART", "N", "." },
+                    new String[] { "POS", "POS", "POS", "POS", "POS" } },
+            { "pt", "mm-perceptron", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Este é um teste .",
+                    new String[] { "PROSUB", "V", "ART", "N", "." },
+                    new String[] { "POS", "POS", "POS", "POS", "POS" } },
+            { "pt", "cogroo", NO_TAGSET_CHECK, NO_TAGSET_CHECK,
+                    "Este é um teste .",
+                    new String[] { "pron-det", "v-fin", "artm", "nm", "." },
+                    new String[] { "POS", "POS", "POS", "POS", "POS" } } };
+    
+    @Parameters(name = "{index}: {0}-{1} {2}: [{4}]")
+    public static Collection<Object[]> data() {
+        return asList(DATA);
+    }
+    
+    private final String language;
+    private final String variant;
+    private final String tagset;
+    private final String[] tags;
+    private final String text;
+    private final String[] originalPos;
+    private final String[] mappedPos;
+    
+    public OpenNlpPosTaggerBulkTest(String aLanguage, String aVariant, String aTagset,
+            String[] aTags, String aText, String[] aOriginalPos, String[] aMappedPos)
+    {
+        language = aLanguage;
+        variant = aVariant;
+        tagset = aTagset;
+        tags = aTags;
+        text = aText;
+        originalPos = aOriginalPos;
+        mappedPos = aMappedPos;
+        
+        if ((tags == null && tagset != null) || (tags != null && tagset == null)) {
+            throw new IllegalArgumentException(
+                    "Tags and tagset must both be specified or both be null");
+        }
+    }
+    
+    @Test
+    public void test()
+        throws Exception
+    {
+        assumeResource(OpenNlpPosTagger.class, "tagger", language, variant);
+        
+        AnalysisEngine engine = createEngine(
+                OpenNlpPosTagger.class,
+                OpenNlpPosTagger.PARAM_VARIANT, variant,
+                OpenNlpPosTagger.PARAM_PRINT_TAGSET, true);
+        
+        JCas jcas = TestRunner.runTest(engine, language, text);
+        
+        assertPOS(mappedPos, originalPos, select(jcas, POS.class));
+ 
+        if (tagset != null) {
+            assertTagset(POS.class, tagset, tags, jcas);
+        }
+    }
+    
+    @Rule
+    public DkproTestContext testContext = new DkproTestContext();
+}

--- a/dkpro-core-opennlp-asl/src/test/java/org/dkpro/core/opennlp/OpenNlpPosTaggerTest.java
+++ b/dkpro-core-opennlp-asl/src/test/java/org/dkpro/core/opennlp/OpenNlpPosTaggerTest.java
@@ -29,13 +29,10 @@ import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
 import org.dkpro.core.api.resources.ResourceObjectProviderBase;
-import org.dkpro.core.opennlp.OpenNlpPosTagger;
-import org.dkpro.core.opennlp.OpenNlpSegmenter;
 import org.dkpro.core.testing.AssertAnnotations;
 import org.dkpro.core.testing.AssumeResource;
 import org.dkpro.core.testing.DkproTestContext;
 import org.dkpro.core.testing.TestRunner;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -141,145 +138,6 @@ public class OpenNlpPosTaggerTest
                 System.getProperties().remove(ResourceObjectProviderBase.PROP_REPO_OFFLINE);
             }
         }
-    }
-    @Test
-    public void testEnglish()
-        throws Exception
-    {
-        runTest("en", null, "This is a test .",
-                new String[] { "DT",   "VBZ", "DT",  "NN",   "." },
-                new String[] { "POS_DET",  "POS_VERB",   "POS_DET", "POS_NOUN",   "POS_PUNCT" });
-
-        runTest("en", null, "A neural net .",
-                new String[] { "DT",  "JJ",     "NN",  "." },
-                new String[] { "POS_DET", "POS_ADJ",    "POS_NOUN",  "POS_PUNCT" });
-
-        runTest("en", null, "John is purchasing oranges .",
-                new String[] { "NNP",  "VBZ", "VBG",      "NNS",    "." },
-                new String[] { "POS_PROPN", "POS_VERB", "POS_VERB", "POS_NOUN", "POS_PUNCT" });
-        
-        // This is WRONG tagging. "jumps" is tagged as "NNS"
-        runTest("en", "maxent", "The quick brown fox jumps over the lazy dog . \n",
-                new String[] { "DT", "JJ", "JJ", "NN", "NNS", "IN", "DT", "JJ", "NN", "." },
-                new String[] { "POS_DET", "POS_ADJ", "POS_ADJ", "POS_NOUN", "POS_NOUN", "POS_ADP",
-                        "POS_DET", "POS_ADJ", "POS_NOUN", "POS_PUNCT" });
-    }
-    
-    @Test
-    public void testEnglishExtra()
-        throws Exception
-    {
-        runTest("en", "perceptron", "The quick brown fox jumps over the lazy dog . \n",
-                new String[] { "DT", "JJ", "JJ", "NN", "NNS", "IN", "DT", "JJ", "NN", "." },
-                new String[] { "POS_DET", "POS_ADJ", "POS_ADJ", "POS_NOUN", "POS_NOUN", "POS_ADP",
-                        "POS_DET", "POS_ADJ", "POS_NOUN", "POS_PUNCT" });
-
-        runTest("en", "perceptron-ixa", "The quick brown fox jumps over the lazy dog . \n",
-                new String[] { "DT", "JJ", "JJ", "NN", "NNS", "IN", "DT", "JJ", "NN", "." },
-                new String[] { "POS_DET", "POS_ADJ", "POS_ADJ", "POS_NOUN", "POS_NOUN", "POS_ADP",
-                        "POS_DET", "POS_ADJ", "POS_NOUN", "POS_PUNCT" });
-    }
-
-    @Test
-    public void testGerman()
-        throws Exception
-    {
-        runTest("de", null, "Das ist ein Test .",
-                new String[] { "PDS", "VAFIN", "ART", "NN",   "$."    },
-                new String[] { "POS_PRON",  "POS_VERB",     "POS_DET", "POS_NOUN",   "POS_PUNCT" });
-
-        runTest("de", "maxent", "Das ist ein Test .",
-                new String[] { "PDS", "VAFIN", "ART", "NN",   "$."    },
-                new String[] { "POS_PRON",  "POS_VERB",     "POS_DET", "POS_NOUN",   "POS_PUNCT" });
-
-        runTest("de", "perceptron", "Das ist ein Test .",
-                new String[] { "PDS", "VAFIN", "ART", "NN",   "$."    },
-                new String[] { "POS_PRON",  "POS_VERB",     "POS_DET", "POS_NOUN",   "POS_PUNCT" });
-    }
-
-    @Test
-    public void testItalian()
-        throws Exception
-    {
-        runTest("it", null, "Questo è un test .",
-                new String[] { "PD", "Vip3", "RI",  "Sn", "FS"    },
-                new String[] { "POS_PRON", "POS_VERB",    "POS_DET", "POS_NOUN", "POS_PUNCT" });
-        
-        runTest("it", "perceptron", "Questo è un test .",
-                new String[] { "PD", "Vip3", "RI",  "Sn", "FS"    },
-                new String[] { "POS_PRON", "POS_VERB",    "POS_DET", "POS_NOUN", "POS_PUNCT" });
-    }
-
-    @Ignore("We don't have these models integrated yet")
-    @Test
-    public void testPortuguese()
-        throws Exception
-    {
-        String[] bosqueTags = new String[] { "?", "adj", "adv", "art", "conj-c", "conj-s", "ec",
-                "in", "n", "num", "pp", "pron-det", "pron-indp", "pron-pers", "prop", "prp",
-                "punc", "v-fin", "v-ger", "v-inf", "v-pcp", "vp" };
-        
-        JCas jcas = runTest("pt", null, "Este é um teste .",
-                new String[] { "pron-det", "v-fin", "art", "n",   "punc" },
-                new String[] { "PRON", "V", "ART", "NN", "PUNC" });
-
-        AssertAnnotations.assertTagset(POS.class, "bosque", bosqueTags, jcas);
-                
-        jcas = runTest("pt", "maxent", "Este é um teste .",
-                new String[] { "pron-det", "v-fin", "art", "n",   "punc" },
-                new String[] { "PRON", "V", "ART", "NN", "PUNC" });
-
-        AssertAnnotations.assertTagset(POS.class, "bosque", bosqueTags, jcas);
-        
-        jcas = runTest("pt", "perceptron", "Este é um teste .",
-                new String[] { "pron-det", "v-fin", "art", "n",   "punc" },
-                new String[] { "PRON", "V", "ART", "NN", "PUNC" });
-
-        AssertAnnotations.assertTagset(POS.class, "bosque", bosqueTags, jcas);
-        
-        jcas = runTest("pt", "mm-maxent", "Este é um teste .",
-                new String[] { "PROSUB", "V",   "ART", "N",   "." },
-                new String[] { "POS",    "POS", "POS", "POS", "POS" });
-
-        // AssertAnnotations.assertTagset(POS.class, "bosque", bosqueTags, jcas);
-        
-        jcas = runTest("pt", "mm-perceptron", "Este é um teste .",
-                new String[] { "PROSUB", "V",   "ART", "N",   "." },
-                new String[] { "POS",    "POS", "POS", "POS", "POS" });
-        
-        // AssertAnnotations.assertTagset(POS.class, "bosque", bosqueTags, jcas);
-        
-        jcas = runTest("pt", "cogroo", "Este é um teste .",
-                new String[] { "pron-det", "v-fin", "artm", "nm", "." },
-                new String[] { "POS",    "POS", "POS", "POS", "POS" });
-        
-        AssertAnnotations.assertTagset(POS.class, "bosque", bosqueTags, jcas);
-    }
-    
-    @Test
-    public void testSpanish()
-        throws Exception
-    {
-        runTest("es", "maxent", "Esta es una prueba .",
-                new String[] { "PD", "VSI", "DI",  "NC", "Fp"   },
-                new String[] { "POS_PRON", "POS_VERB",   "POS_DET", "POS_NOUN", "POS_PUNCT" });
-
-        runTest("es", "maxent-ixa", "Esta es una prueba .", 
-                new String[] { "PD0FS000", "VSIP3S0", "DI0FS0", "NCFS000", "Fp"}, 
-                new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" });
-
-        runTest("es", "perceptron-ixa", "Esta es una prueba .",
-                new String[] { "PD0FS000", "VSIP3S0", "DI0FS0", "NCFS000", "Fp"}, 
-                new String[] { "POS_PRON", "POS_VERB", "POS_DET", "POS_NOUN", "POS_PUNCT" });
-    }
-
-    @Test
-    public void testSwedish()
-        throws Exception
-    {
-        runTest("sv", "maxent", "Detta är ett test .",
-                new String[] { "PO",  "AV",  "EN",  "NN",  "IP"    },
-                new String[] { "POS", "POS", "POS", "POS", "POS" });
     }
 
     private JCas runTest(String language, String variant, String testDocument, String[] tags,


### PR DESCRIPTION
- Removed the IXA models that are no longer there from the build.xml script (keep them in the POM though)
- Update to a newer version of the Ant packaging script
- Slight refactoring of the POS tests