### PR TITLE
#1467 - Upgrade dependencies (DKPro Core 2.2.0)

### DIFF
--- a/dkpro-core-api-anomaly-asl/pom.xml
+++ b/dkpro-core-api-anomaly-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-anomaly-asl</artifactId>

--- a/dkpro-core-api-coref-asl/pom.xml
+++ b/dkpro-core-api-coref-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-coref-asl</artifactId>

--- a/dkpro-core-api-datasets-asl/pom.xml
+++ b/dkpro-core-api-datasets-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-datasets-asl</artifactId>

--- a/dkpro-core-api-datasets-asl/src/main/java/org/dkpro/core/api/datasets/DatasetFactory.java
+++ b/dkpro-core-api-datasets-asl/src/main/java/org/dkpro/core/api/datasets/DatasetFactory.java
@@ -195,7 +195,7 @@ public class DatasetFactory
         // Load the YAML descriptions
         Map<String, DatasetDescriptionImpl> sets = new LinkedHashMap<>();
         for (Resource res : resources) {
-            LOG.debug("Loading [" + res + "]");
+            LOG.trace("Loading [" + res + "]");
             try (InputStream is = res.getInputStream()) {
                 String id = FilenameUtils.getBaseName(res.getFilename());
                 DatasetDescriptionImpl ds = yaml.loadAs(is, DatasetDescriptionImpl.class);
@@ -211,6 +211,9 @@ public class DatasetFactory
                 sets.put(ds.getId(), ds);
             }
         }
+        
+        LOG.debug("Loaded [" + sets.size() + "] dataset description");
+
         
         return sets;
     }

--- a/dkpro-core-api-discourse-asl/pom.xml
+++ b/dkpro-core-api-discourse-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-discourse-asl</artifactId>

--- a/dkpro-core-api-embeddings-asl/pom.xml
+++ b/dkpro-core-api-embeddings-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-embeddings-asl</artifactId>

--- a/dkpro-core-api-featurepath-asl/pom.xml
+++ b/dkpro-core-api-featurepath-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-featurepath-asl</artifactId>

--- a/dkpro-core-api-frequency-asl/pom.xml
+++ b/dkpro-core-api-frequency-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-frequency-asl</artifactId>

--- a/dkpro-core-api-io-asl/pom.xml
+++ b/dkpro-core-api-io-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-io-asl</artifactId>

--- a/dkpro-core-api-lexmorph-asl/pom.xml
+++ b/dkpro-core-api-lexmorph-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-lexmorph-asl</artifactId>

--- a/dkpro-core-api-metadata-asl/pom.xml
+++ b/dkpro-core-api-metadata-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-metadata-asl</artifactId>

--- a/dkpro-core-api-metadata-asl/suppressions.xml
+++ b/dkpro-core-api-metadata-asl/suppressions.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <suppress files=".*[/\\]target[/\\].*" checks=".*"/>
+    <suppress files=".*[/\\]de[/\\]tudarmstadt[/\\]ukp[/\\]dkpro[/\\]core[/\\]api[/\\]metadata[/\\]type[/\\].*" checks=".*"/>
 </suppressions>

--- a/dkpro-core-api-ner-asl/pom.xml
+++ b/dkpro-core-api-ner-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/dkpro-core-api-parameter-asl/pom.xml
+++ b/dkpro-core-api-parameter-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/dkpro-core-api-phonetics-asl/pom.xml
+++ b/dkpro-core-api-phonetics-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-phonetics-asl</artifactId>

--- a/dkpro-core-api-resources-asl/pom.xml
+++ b/dkpro-core-api-resources-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-resources-asl</artifactId>

--- a/dkpro-core-api-resources-asl/src/main/java/org/dkpro/core/api/resources/ResourceObjectProviderBase.java
+++ b/dkpro-core-api-resources-asl/src/main/java/org/dkpro/core/api/resources/ResourceObjectProviderBase.java
@@ -569,7 +569,7 @@ public abstract class ResourceObjectProviderBase<M>
                 resourceUrl = null;
                 initialResourceUrl = null;
                 if (modelLocationChanged) {
-                    log.info("Producing resource from thin air");
+                    log.debug("Producing resource from thin air");
                     loadResource(props);
                 }
             }
@@ -605,14 +605,14 @@ public abstract class ResourceObjectProviderBase<M>
                     if (resourceUrl == null) {
                         initialResourceUrl = null;
                         if (modelLocationChanged) {
-                            log.info("Producing resource from thin air");
+                            log.debug("Producing resource from thin air");
                             loadResource(props);
                         }
                     } 
                     else {
                         loadMetadata();
                         if (initialResourceUrl.equals(resourceUrl)) {
-                            log.info("Producing resource from " + resourceUrl);
+                            log.info("Producing resource from [" + resourceUrl + "]");
                         }
                         else {
                             log.info("Producing resource from [" + resourceUrl + "] redirected from ["
@@ -761,7 +761,7 @@ public abstract class ResourceObjectProviderBase<M>
             sw.start();
             resource = produceResource(resourceUrl);
             sw.stop();
-            log.info("Producing resource took " + sw.getTime() + "ms");
+            log.trace("Producing resource took " + sw.getTime() + "ms");
 
             // If cache is enabled, update the cache
             if (sharable) {

--- a/dkpro-core-api-segmentation-asl/pom.xml
+++ b/dkpro-core-api-segmentation-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-segmentation-asl</artifactId>

--- a/dkpro-core-api-segmentation-asl/suppressions.xml
+++ b/dkpro-core-api-segmentation-asl/suppressions.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <suppress files=".*[/\\]target[/\\].*" checks=".*"/>
+    <suppress files=".*[/\\]de[/\\]tudarmstadt[/\\]ukp[/\\]dkpro[/\\]core[/\\]api[/\\]segmentation[/\\]type[/\\].*" checks=".*"/>
 </suppressions>

--- a/dkpro-core-api-semantics-asl/pom.xml
+++ b/dkpro-core-api-semantics-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-semantics-asl</artifactId>

--- a/dkpro-core-api-sentiment-asl/pom.xml
+++ b/dkpro-core-api-sentiment-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-sentiment-asl</artifactId>

--- a/dkpro-core-api-structure-asl/pom.xml
+++ b/dkpro-core-api-structure-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-structure-asl</artifactId>

--- a/dkpro-core-api-syntax-asl/pom.xml
+++ b/dkpro-core-api-syntax-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-syntax-asl</artifactId>

--- a/dkpro-core-api-transform-asl/pom.xml
+++ b/dkpro-core-api-transform-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-transform-asl</artifactId>

--- a/dkpro-core-api-xml-asl/pom.xml
+++ b/dkpro-core-api-xml-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-api-xml-asl</artifactId>

--- a/dkpro-core-arktools-gpl/pom.xml
+++ b/dkpro-core-arktools-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <artifactId>dkpro-core-arktools-gpl</artifactId>

--- a/dkpro-core-asl/pom.xml
+++ b/dkpro-core-asl/pom.xml
@@ -174,7 +174,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-flextag-asl</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.1.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
@@ -284,7 +284,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-lcc-asl</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.1.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
@@ -509,7 +509,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>org-dkpro-core-smile-asl</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.1.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
@@ -539,7 +539,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>org-dkpro-core-udpipe-asl</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.1.1-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -671,22 +671,22 @@
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-io-annis-asl</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.1.1-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-io-rdf-asl</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.1.1-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-cogroo-asl</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.1.1-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-kuromoji-asl</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.1.1-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>org.dkpro.core</groupId>
@@ -740,7 +740,7 @@
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-illinoisnlp-asl</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.1.1-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/dkpro-core-asl/pom.xml
+++ b/dkpro-core-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dkpro-core-asl</artifactId>
@@ -39,507 +39,507 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-anomaly-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-datasets-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-embeddings-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-featurepath-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-frequency-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-io-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-coref-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-lexmorph-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-metadata-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-ner-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-parameter-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-phonetics-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-resources-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-segmentation-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-semantics-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-sentiment-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-structure-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-syntax-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-transform-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-api-xml-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-castransformation-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-cisstem-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-clearnlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-commonscodec-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-decompounding-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-dictionaryannotator-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-eval-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-flextag-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-frequency-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-gate-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-hunpos-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-fs-hdfs-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-gosen-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-icu-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-aclanthology-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-ancora-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-bincas-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-bliki-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-bnc-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-brat-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-combination-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-conll-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-ditop-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-gigaword-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-html-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-imscwb-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-json-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-jdbc-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-jwpl-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-lcc-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-lif-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-lxf-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-negra-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-nif-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-nitf-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-pdf-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-penntree-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-perseus-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-pubannotation-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-rtf-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-solr-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-tcf-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-tei-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-text-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-tiger-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-tika-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-webanno-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-tuebadz-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-tuepp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-web1t-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-xmi-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-xml-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-xces-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-ixa-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-jazzy-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-jtok-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
      <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-languagetool-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-langdetect-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-ldweb1t-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-mallet-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-maltparser-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-morpha-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-mstparser-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-mecab-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-mystem-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-ngrams-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-nlp4j-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-norvig-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-performance-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-posfilter-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-readability-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-rftagger-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-snowball-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>org-dkpro-core-smile-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-testing-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-textcat-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-tokit-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-treetagger-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-textnormalizer-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>org-dkpro-core-udpipe-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -671,27 +671,27 @@
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-io-annis-asl</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-io-rdf-asl</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-cogroo-asl</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-kuromoji-asl</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
           </dependency>
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-gate-asl</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </dependencyManagement>
@@ -740,7 +740,7 @@
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-illinoisnlp-asl</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/dkpro-core-berkeleyparser-gpl/pom.xml
+++ b/dkpro-core-berkeleyparser-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <artifactId>dkpro-core-berkeleyparser-gpl</artifactId>
@@ -162,7 +162,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-build/pom.xml
+++ b/dkpro-core-build/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dkpro-core-build</artifactId>

--- a/dkpro-core-build/src/main/resources/dkpro-core/version-rules.xml
+++ b/dkpro-core-build/src/main/resources/dkpro-core/version-rules.xml
@@ -1,0 +1,75 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*-alpha[0-9]*</ignoreVersion>
+    <ignoreVersion type="regex">.*-beta[0-9]*</ignoreVersion>
+    <ignoreVersion type="regex">.*\.rc[0-9]*</ignoreVersion>
+    <ignoreVersion type="regex">.*-M[0-9]*</ignoreVersion>
+    <ignoreVersion type="regex">.*-b[0-9]+</ignoreVersion>
+    <ignoreVersion type="regex">.*-b[0-9]+\.[0-9]+</ignoreVersion>
+    <ignoreVersion type="regex">.*-atlassian.*</ignoreVersion>
+  </ignoreVersions>
+  <rules>
+    <rule groupId="commons-collections" artifactId="commons-collections" comparisonMethod="maven">
+      <ignoreVersions>
+        <ignoreVersion type="regex">[0-9]{8}(\.[0-9]{6})?</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    
+    <rule groupId="dom4j" artifactId="dom4j" comparisonMethod="maven">
+      <ignoreVersions>
+        <ignoreVersion>20040902.021138</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    
+    <!-- PIN: Spring 4.x -->
+    <rule groupId="org.springframework" comparisonMethod="maven"> 
+      <ignoreVersions>
+        <ignoreVersion type="regex">^5.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    
+    <!-- PIN: Xerces 2.9.1 -->
+    <rule groupId="xerces" artifactId="xercesImpl" comparisonMethod="maven"> 
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+
+    <!-- PIN: stax2-api 3.x -->
+    <rule groupId="org.codehaus.woodstox" artifactId="stax2-api" comparisonMethod="maven"> 
+      <ignoreVersions>
+        <ignoreVersion type="regex">^4.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+
+    <!-- PIN: Lucene 4.4.x -->
+    <rule groupId="org.apache.lucene" comparisonMethod="maven"> 
+      <ignoreVersions>
+        <ignoreVersion type="regex">^[4-9].*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    
+    <!-- PIN: Berkeleyparser r32 -->
+    <rule groupId="edu.berkeley.nlp" artifactId="berkeleyparser" comparisonMethod="maven"> 
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+
+    <!-- Ignore old versions: jtok -->
+    <rule groupId="de.dfki.lt.jtok" artifactId="jtok-core" comparisonMethod="maven"> 
+      <ignoreVersions>
+        <ignoreVersion type="regex">2\.[0-9]{2}</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    
+    <!-- Bad models? -->
+    <rule groupId="de.tudarmstadt.ukp.dkpro.core" artifactId="de.tudarmstadt.ukp.dkpro.core.matetools-model-*" comparisonMethod="maven"> 
+      <ignoreVersions>
+        <ignoreVersion>20140113.0</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+  </rules>
+</ruleset>

--- a/dkpro-core-build/src/main/resources/dkpro-core/version-rules.xml
+++ b/dkpro-core-build/src/main/resources/dkpro-core/version-rules.xml
@@ -58,6 +58,17 @@
       </ignoreVersions>
     </rule>
 
+    <!-- 
+      - PIN: Berkeleyparser 0.232 
+      - 
+      - Upgrading to newer version breaks deserialization of StanfordNLP coref models.
+      -->
+    <rule groupId="com.googlecode.efficient-java-matrix-library" artifactId="ejml" comparisonMethod="maven"> 
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+
     <!-- Ignore old versions: jtok -->
     <rule groupId="de.dfki.lt.jtok" artifactId="jtok-core" comparisonMethod="maven"> 
       <ignoreVersions>

--- a/dkpro-core-castransformation-asl/pom.xml
+++ b/dkpro-core-castransformation-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-castransformation-asl</artifactId>

--- a/dkpro-core-cisstem-asl/pom.xml
+++ b/dkpro-core-cisstem-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-cisstem-asl</artifactId>

--- a/dkpro-core-clearnlp-asl/pom.xml
+++ b/dkpro-core-clearnlp-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-clearnlp-asl</artifactId>
@@ -176,7 +176,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-cogroo-asl/pom.xml
+++ b/dkpro-core-cogroo-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-cogroo-asl</artifactId>

--- a/dkpro-core-cogroo-asl/pom.xml
+++ b/dkpro-core-cogroo-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-cogroo-asl</artifactId>

--- a/dkpro-core-commonscodec-asl/pom.xml
+++ b/dkpro-core-commonscodec-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-commonscodec-asl</artifactId>

--- a/dkpro-core-corenlp-gpl/pom.xml
+++ b/dkpro-core-corenlp-gpl/pom.xml
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
         <artifactId>de.tudarmstadt.ukp.dkpro.core.stanfordnlp-model-parser-ar-sr</artifactId>
-        <version>20141031.1</version>
+        <version>20180227.1</version>
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
@@ -381,7 +381,7 @@
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
         <artifactId>de.tudarmstadt.ukp.dkpro.core.stanfordnlp-model-tagger-en-wsj-0-18-left3words-distsim</artifactId>
-        <version>20131112.1</version>
+        <version>20140616.1</version>
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
@@ -521,7 +521,7 @@
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
         <artifactId>de.tudarmstadt.ukp.dkpro.core.corenlp-model-depparser-en-ud</artifactId>
-        <version>20150418.1</version>
+        <version>20161213.1</version>
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>

--- a/dkpro-core-corenlp-gpl/pom.xml
+++ b/dkpro-core-corenlp-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <artifactId>dkpro-core-corenlp-gpl</artifactId>

--- a/dkpro-core-corenlp-gpl/src/test/java/org/dkpro/core/corenlp/CoreNlpDependencyParserTest.java
+++ b/dkpro-core-corenlp-gpl/src/test/java/org/dkpro/core/corenlp/CoreNlpDependencyParserTest.java
@@ -27,8 +27,6 @@ import static org.dkpro.core.testing.AssertAnnotations.assertTagsetMapping;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.uima.fit.factory.AggregateBuilder;
 import org.apache.uima.jcas.JCas;
-import org.dkpro.core.corenlp.CoreNlpDependencyParser;
-import org.dkpro.core.corenlp.CoreNlpPosTagger;
 import org.dkpro.core.testing.AssumeResource;
 import org.dkpro.core.testing.DkproTestContext;
 import org.dkpro.core.testing.TestRunner;
@@ -125,9 +123,9 @@ public class CoreNlpDependencyParserTest
                 "[ 44, 45]PUNCT(punct,basic) D[44,45](,) G[35,43](sentence)",
                 "[ 46, 51]NSUBJ(nsubj,basic) D[46,51](which) G[52,60](contains)",
                 "[ 52, 60]Dependency(acl:relcl,basic) D[52,60](contains) G[35,43](sentence)",
-                "[ 61, 63]PREP(case,basic) D[61,63](as) G[69,81](constituents)",
+                "[ 61, 63]DOBJ(dobj,basic) D[61,63](as) G[52,60](contains)",
                 "[ 64, 68]AMOD(amod,basic) D[64,68](many) G[69,81](constituents)",
-                "[ 69, 81]Dependency(nmod:as,basic) D[69,81](constituents) G[52,60](contains)",
+                "[ 69, 81]DEP(dep,basic) D[69,81](constituents) G[61,63](as)",
                 "[ 82, 85]CC(cc,basic) D[82,85](and) G[69,81](constituents)",
                 "[ 86, 98]CONJ(conj:and,basic) D[86,98](dependencies) G[69,81](constituents)",
                 "[ 99,101]PREP(case,basic) D[99,101](as) G[102,110](possible)",

--- a/dkpro-core-decompounding-asl/pom.xml
+++ b/dkpro-core-decompounding-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <name>DKPro Core ASL - Decompounding</name>

--- a/dkpro-core-dictionaryannotator-asl/pom.xml
+++ b/dkpro-core-dictionaryannotator-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-dictionaryannotator-asl</artifactId>

--- a/dkpro-core-doc/pom.xml
+++ b/dkpro-core-doc/pom.xml
@@ -126,7 +126,7 @@
           <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.19</version>
+            <version>${snakeyaml.version}</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/dkpro-core-doc/pom.xml
+++ b/dkpro-core-doc/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/dkpro-core-eval-asl/pom.xml
+++ b/dkpro-core-eval-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-eval-asl</artifactId>

--- a/dkpro-core-flextag-asl/pom.xml
+++ b/dkpro-core-flextag-asl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-flextag-asl</artifactId>

--- a/dkpro-core-flextag-asl/pom.xml
+++ b/dkpro-core-flextag-asl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-flextag-asl</artifactId>

--- a/dkpro-core-frequency-asl/pom.xml
+++ b/dkpro-core-frequency-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-frequency-asl</artifactId>

--- a/dkpro-core-fs-hdfs-asl/pom.xml
+++ b/dkpro-core-fs-hdfs-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-fs-hdfs-asl</artifactId>

--- a/dkpro-core-gate-asl/pom.xml
+++ b/dkpro-core-gate-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-gate-asl</artifactId>
@@ -110,7 +110,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-gosen-asl/pom.xml
+++ b/dkpro-core-gosen-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-gosen-asl</artifactId>

--- a/dkpro-core-gpl/pom.xml
+++ b/dkpro-core-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>dkpro-core-gpl</artifactId>
@@ -42,59 +42,59 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-arktools-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-berkeleyparser-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-corenlp-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-lingpipe-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-tgrep-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-matetools-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-maui-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-sfst-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-stanfordnlp-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-cermine-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -179,7 +179,7 @@
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-io-cermine-gpl</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/dkpro-core-gpl/pom.xml
+++ b/dkpro-core-gpl/pom.xml
@@ -94,7 +94,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-cermine-gpl</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.1.1-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -179,7 +179,7 @@
           <dependency>
             <groupId>org.dkpro.core</groupId>
             <artifactId>dkpro-core-io-cermine-gpl</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.1.1-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/dkpro-core-hunpos-asl/pom.xml
+++ b/dkpro-core-hunpos-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-hunpos-asl</artifactId>

--- a/dkpro-core-icu-asl/pom.xml
+++ b/dkpro-core-icu-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-icu-asl</artifactId>

--- a/dkpro-core-illinoisnlp-asl/pom.xml
+++ b/dkpro-core-illinoisnlp-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-illinoisnlp-asl</artifactId>

--- a/dkpro-core-illinoisnlp-asl/pom.xml
+++ b/dkpro-core-illinoisnlp-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-illinoisnlp-asl</artifactId>

--- a/dkpro-core-io-aclanthology-asl/pom.xml
+++ b/dkpro-core-io-aclanthology-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-aclanthology-asl</artifactId>

--- a/dkpro-core-io-ancora-asl/pom.xml
+++ b/dkpro-core-io-ancora-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-ancora-asl</artifactId>

--- a/dkpro-core-io-annis-asl/pom.xml
+++ b/dkpro-core-io-annis-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-annis-asl</artifactId>

--- a/dkpro-core-io-annis-asl/pom.xml
+++ b/dkpro-core-io-annis-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-annis-asl</artifactId>

--- a/dkpro-core-io-bincas-asl/pom.xml
+++ b/dkpro-core-io-bincas-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-bincas-asl</artifactId>

--- a/dkpro-core-io-bliki-asl/pom.xml
+++ b/dkpro-core-io-bliki-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-bliki-asl</artifactId>

--- a/dkpro-core-io-bnc-asl/pom.xml
+++ b/dkpro-core-io-bnc-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-bnc-asl</artifactId>

--- a/dkpro-core-io-brat-asl/pom.xml
+++ b/dkpro-core-io-brat-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-brat-asl</artifactId>

--- a/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/mapping/CommentMapping.java
+++ b/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/mapping/CommentMapping.java
@@ -39,7 +39,16 @@ public class CommentMapping
     
     private Matcher matcher;
     private String value;
-    
+
+    /**
+     * Jackson requires this constructor - even if it is private - do not use!
+     */
+    @SuppressWarnings("unused")
+    private CommentMapping()
+    {
+        this(null, null, null, null);
+    }
+
     @JsonCreator
     public CommentMapping(
             @JsonProperty("type") String aType, 

--- a/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/mapping/Mapping.java
+++ b/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/mapping/Mapping.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Mapping
@@ -38,15 +39,13 @@ public class Mapping
     private final Map<String, RelationMapping> relations;
     private final MultiValuedMap<String, CommentMapping> comments;
     
+    @JsonCreator
     public Mapping(
-            @JsonProperty(value = "textTypeMapppings", required = false) 
-            TypeMappings aTextTypeMapppings, 
-            @JsonProperty(value = "relationTypeMapppings", required = false) 
-            TypeMappings aRelationTypeMapppings, 
-            @JsonProperty(value = "spans", required = false) 
-            List<SpanMapping> aTextAnnotations,
-            @JsonProperty(value = "relations", required = false) List<RelationMapping> aRelations, 
-            @JsonProperty(value = "comments", required = false) List<CommentMapping> aComments)
+            @JsonProperty(value = "textTypeMapppings") TypeMappings aTextTypeMapppings, 
+            @JsonProperty(value = "relationTypeMapppings") TypeMappings aRelationTypeMapppings, 
+            @JsonProperty(value = "spans") List<SpanMapping> aTextAnnotations,
+            @JsonProperty(value = "relations") List<RelationMapping> aRelations, 
+            @JsonProperty(value = "comments") List<CommentMapping> aComments)
     {
         textTypeMapppings = aTextTypeMapppings;
         relationTypeMapppings = aRelationTypeMapppings;

--- a/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/mapping/RelationMapping.java
+++ b/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/mapping/RelationMapping.java
@@ -50,6 +50,15 @@ public class RelationMapping
     private final String subcat;
     private final Map<String, String> defaultFeatureValues;
     
+    /**
+     * Jackson requires this constructor - even if it is private - do not use!
+     */
+    @SuppressWarnings("unused")
+    private RelationMapping()
+    {
+        this(null, null, null, null, null, null);
+    }
+    
     @JsonCreator
     public RelationMapping(
             @JsonProperty(value = "type", required = true) String aType, 

--- a/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/mapping/SpanMapping.java
+++ b/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/mapping/SpanMapping.java
@@ -40,6 +40,15 @@ public class SpanMapping
     private final String subcat;
     private final Map<String, String> defaultFeatureValues;
     
+    /**
+     * Jackson requires this constructor - even if it is private - do not use!
+     */
+    @SuppressWarnings("unused")
+    private SpanMapping()
+    {
+        this(null, null);
+    }
+    
     @JsonCreator
     public SpanMapping(
             @JsonProperty(value = "type", required = true) String aType, 

--- a/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/model/BratAnnotationDocument.java
+++ b/dkpro-core-io-brat-asl/src/main/java/org/dkpro/core/io/brat/internal/model/BratAnnotationDocument.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
-import org.dkpro.core.io.brat.internal.model.BratNoteAnnotation;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 

--- a/dkpro-core-io-cermine-gpl/pom.xml
+++ b/dkpro-core-io-cermine-gpl/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/dkpro-core-io-cermine-gpl/pom.xml
+++ b/dkpro-core-io-cermine-gpl/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/dkpro-core-io-combination-asl/pom.xml
+++ b/dkpro-core-io-combination-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-combination-asl</artifactId>

--- a/dkpro-core-io-conll-asl/pom.xml
+++ b/dkpro-core-io-conll-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-conll-asl</artifactId>

--- a/dkpro-core-io-ditop-asl/pom.xml
+++ b/dkpro-core-io-ditop-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-ditop-asl</artifactId>

--- a/dkpro-core-io-gate-asl/pom.xml
+++ b/dkpro-core-io-gate-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-gate-asl</artifactId>

--- a/dkpro-core-io-gate-asl/pom.xml
+++ b/dkpro-core-io-gate-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-gate-asl</artifactId>

--- a/dkpro-core-io-gigaword-asl/pom.xml
+++ b/dkpro-core-io-gigaword-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-gigaword-asl</artifactId>

--- a/dkpro-core-io-html-asl/pom.xml
+++ b/dkpro-core-io-html-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-html-asl</artifactId>

--- a/dkpro-core-io-imscwb-asl/pom.xml
+++ b/dkpro-core-io-imscwb-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-imscwb-asl</artifactId>
@@ -113,7 +113,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-io-jdbc-asl/pom.xml
+++ b/dkpro-core-io-jdbc-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-jdbc-asl</artifactId>

--- a/dkpro-core-io-jdbc-asl/pom.xml
+++ b/dkpro-core-io-jdbc-asl/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.2</version>
+      <version>2.5.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dkpro-core-io-json-asl/pom.xml
+++ b/dkpro-core-io-json-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-json-asl</artifactId>

--- a/dkpro-core-io-jwpl-asl/pom.xml
+++ b/dkpro-core-io-jwpl-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-jwpl-asl</artifactId>

--- a/dkpro-core-io-lcc-asl/pom.xml
+++ b/dkpro-core-io-lcc-asl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-lcc-asl</artifactId>

--- a/dkpro-core-io-lcc-asl/pom.xml
+++ b/dkpro-core-io-lcc-asl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-lcc-asl</artifactId>

--- a/dkpro-core-io-lif-asl/pom.xml
+++ b/dkpro-core-io-lif-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-lif-asl</artifactId>

--- a/dkpro-core-io-lxf-asl/pom.xml
+++ b/dkpro-core-io-lxf-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-lxf-asl</artifactId>
@@ -101,7 +101,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-io-negra-asl/pom.xml
+++ b/dkpro-core-io-negra-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-negra-asl</artifactId>

--- a/dkpro-core-io-nif-asl/pom.xml
+++ b/dkpro-core-io-nif-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-nif-asl</artifactId>

--- a/dkpro-core-io-nif-asl/pom.xml
+++ b/dkpro-core-io-nif-asl/pom.xml
@@ -30,12 +30,12 @@
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-core</artifactId>
-      <version>3.5.0</version>
+      <version>3.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-arq</artifactId>
-      <version>3.5.0</version>
+      <version>3.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/dkpro-core-io-nitf-asl/pom.xml
+++ b/dkpro-core-io-nitf-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-nitf-asl</artifactId>

--- a/dkpro-core-io-pdf-asl/pom.xml
+++ b/dkpro-core-io-pdf-asl/pom.xml
@@ -28,7 +28,7 @@
   <name>DKPro Core ASL - IO - PDF</name>
   <url>https://dkpro.github.io/dkpro-core/</url>
   <properties>
-    <pdfbox.version>2.0.12</pdfbox.version>
+    <pdfbox.version>2.0.19</pdfbox.version>
   </properties>
   <dependencies>
     <dependency>

--- a/dkpro-core-io-pdf-asl/pom.xml
+++ b/dkpro-core-io-pdf-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-pdf-asl</artifactId>

--- a/dkpro-core-io-penntree-asl/pom.xml
+++ b/dkpro-core-io-penntree-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-penntree-asl</artifactId>
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-io-perseus-asl/pom.xml
+++ b/dkpro-core-io-perseus-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-perseus-asl</artifactId>

--- a/dkpro-core-io-pubannotation-asl/pom.xml
+++ b/dkpro-core-io-pubannotation-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-pubannotation-asl</artifactId>

--- a/dkpro-core-io-rdf-asl/pom.xml
+++ b/dkpro-core-io-rdf-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-rdf-asl</artifactId>

--- a/dkpro-core-io-rdf-asl/pom.xml
+++ b/dkpro-core-io-rdf-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-rdf-asl</artifactId>

--- a/dkpro-core-io-reuters-asl/pom.xml
+++ b/dkpro-core-io-reuters-asl/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/dkpro-core-io-rtf-asl/pom.xml
+++ b/dkpro-core-io-rtf-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-rtf-asl</artifactId>

--- a/dkpro-core-io-solr-asl/pom.xml
+++ b/dkpro-core-io-solr-asl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-solr-asl</artifactId>

--- a/dkpro-core-io-tcf-asl/pom.xml
+++ b/dkpro-core-io-tcf-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-tcf-asl</artifactId>

--- a/dkpro-core-io-tcf-asl/pom.xml
+++ b/dkpro-core-io-tcf-asl/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>eu.clarin.weblicht</groupId>
       <artifactId>wlfxb</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/dkpro-core-io-tei-asl/pom.xml
+++ b/dkpro-core-io-tei-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-tei-asl</artifactId>
@@ -166,7 +166,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-io-tei-asl/src/test/java/org/dkpro/core/io/tei/TeiReaderTest.java
+++ b/dkpro-core-io-tei-asl/src/test/java/org/dkpro/core/io/tei/TeiReaderTest.java
@@ -31,8 +31,8 @@ import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.JCas;
 import org.assertj.core.api.ListAssert;
 import org.dkpro.core.io.imscwb.ImsCwbWriter;
-import org.dkpro.core.testing.ReaderAssert;
 import org.dkpro.core.testing.DkproTestContext;
+import org.dkpro.core.testing.ReaderAssert;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/dkpro-core-io-text-asl/pom.xml
+++ b/dkpro-core-io-text-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-text-asl</artifactId>

--- a/dkpro-core-io-tgrep-gpl/pom.xml
+++ b/dkpro-core-io-tgrep-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-tgrep-gpl</artifactId>
@@ -93,7 +93,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-stanfordnlp-gpl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/dkpro-core-io-tiger-asl/pom.xml
+++ b/dkpro-core-io-tiger-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-tiger-asl</artifactId>
@@ -145,7 +145,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/dkpro-core-io-tika-asl/pom.xml
+++ b/dkpro-core-io-tika-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-tika-asl</artifactId>

--- a/dkpro-core-io-tika-asl/pom.xml
+++ b/dkpro-core-io-tika-asl/pom.xml
@@ -69,13 +69,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
-      <version>1.7.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dkpro-core-io-tuebadz-asl/pom.xml
+++ b/dkpro-core-io-tuebadz-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-tuebadz-asl</artifactId>

--- a/dkpro-core-io-tuepp-asl/pom.xml
+++ b/dkpro-core-io-tuepp-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-tuepp-asl</artifactId>

--- a/dkpro-core-io-web1t-asl/pom.xml
+++ b/dkpro-core-io-web1t-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-web1t-asl</artifactId>
@@ -142,14 +142,14 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-clearnlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-io-webanno-asl/pom.xml
+++ b/dkpro-core-io-webanno-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-webanno-asl</artifactId>

--- a/dkpro-core-io-xces-asl/pom.xml
+++ b/dkpro-core-io-xces-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-xces-asl</artifactId>

--- a/dkpro-core-io-xmi-asl/pom.xml
+++ b/dkpro-core-io-xmi-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-xmi-asl</artifactId>

--- a/dkpro-core-io-xml-asl/pom.xml
+++ b/dkpro-core-io-xml-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-io-xml-asl</artifactId>

--- a/dkpro-core-ixa-asl/pom.xml
+++ b/dkpro-core-ixa-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-ixa-asl</artifactId>
@@ -142,7 +142,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-ixa-asl/pom.xml
+++ b/dkpro-core-ixa-asl/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>eus.ixa</groupId>
       <artifactId>ixa-pipe-pos</artifactId>
-      <version>1.5.1</version>
+      <version>1.5.3</version>
     </dependency>
     <!--
       <dependency>

--- a/dkpro-core-jazzy-asl/pom.xml
+++ b/dkpro-core-jazzy-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-jazzy-asl</artifactId>

--- a/dkpro-core-jieba-asl/pom.xml
+++ b/dkpro-core-jieba-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-jieba-asl</artifactId>

--- a/dkpro-core-jtok-asl/pom.xml
+++ b/dkpro-core-jtok-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-jtok-asl</artifactId>

--- a/dkpro-core-jtok-asl/pom.xml
+++ b/dkpro-core-jtok-asl/pom.xml
@@ -28,7 +28,7 @@
   <name>DKPro Core ASL - JTok (v ${jtok.version}) (LGPL)</name>
   <url>https://dkpro.github.io/dkpro-core/</url>
   <properties>
-    <jtok.version>2.1.18</jtok.version>
+    <jtok.version>2.1.19</jtok.version>
   </properties>
   <dependencies>
     <dependency>

--- a/dkpro-core-kuromoji-asl/pom.xml
+++ b/dkpro-core-kuromoji-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-kuromoji-asl</artifactId>

--- a/dkpro-core-kuromoji-asl/pom.xml
+++ b/dkpro-core-kuromoji-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-kuromoji-asl</artifactId>

--- a/dkpro-core-langdetect-asl/pom.xml
+++ b/dkpro-core-langdetect-asl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-langdetect-asl</artifactId>

--- a/dkpro-core-languagetool-asl/pom.xml
+++ b/dkpro-core-languagetool-asl/pom.xml
@@ -29,7 +29,7 @@
   <url>https://dkpro.github.io/dkpro-core/</url>
   <description>Grammar checker based on LanguageTool (LGPL)</description>
   <properties>
-    <languagetool.version>4.3</languagetool.version>
+    <languagetool.version>4.9</languagetool.version>
   </properties>
   <dependencies>
     <dependency>

--- a/dkpro-core-languagetool-asl/pom.xml
+++ b/dkpro-core-languagetool-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-languagetool-asl</artifactId>
@@ -124,7 +124,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-languagetool-asl/src/test/java/org/dkpro/core/languagetool/LanguageToolSegmenterTest.java
+++ b/dkpro-core-languagetool-asl/src/test/java/org/dkpro/core/languagetool/LanguageToolSegmenterTest.java
@@ -100,7 +100,7 @@ public class LanguageToolSegmenterTest
         AnalysisEngine aed = createEngine(LanguageToolSegmenter.class);
         aed.process(jcas);
         
-        String[] tokens = { "毛澤東", "住", "在", "北京" };
+        String[] tokens = { "毛", "澤東", "住", "在", "北京" };
         
         AssertAnnotations.assertToken(tokens, select(jcas, Token.class));
     }

--- a/dkpro-core-lbj-asl/pom.xml
+++ b/dkpro-core-lbj-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
     <artifactId>de.tudarmstadt.ukp.dkpro.core-asl</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>de.tudarmstadt.ukp.dkpro.core.lbj-asl</artifactId>

--- a/dkpro-core-lbj-asl/pom.xml
+++ b/dkpro-core-lbj-asl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
     <artifactId>de.tudarmstadt.ukp.dkpro.core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>de.tudarmstadt.ukp.dkpro.core.lbj-asl</artifactId>

--- a/dkpro-core-ldweb1t-asl/pom.xml
+++ b/dkpro-core-ldweb1t-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-ldweb1t-asl</artifactId>

--- a/dkpro-core-lingpipe-gpl/pom.xml
+++ b/dkpro-core-lingpipe-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <artifactId>dkpro-core-lingpipe-gpl</artifactId>

--- a/dkpro-core-lingpipe-gpl/pom.xml
+++ b/dkpro-core-lingpipe-gpl/pom.xml
@@ -31,7 +31,7 @@
   <name>DKPro Core GPL - LingPipe (v ${lingpipe.version})</name>
   <url>https://dkpro.github.io/dkpro-core/</url>
   <properties>
-    <lingpipe.version>4.1.0</lingpipe.version>
+    <lingpipe.version>4.1.2-JL1.0</lingpipe.version>
   </properties>
   <dependencies>
     <dependency>

--- a/dkpro-core-mallet-asl/pom.xml
+++ b/dkpro-core-mallet-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-mallet-asl</artifactId>

--- a/dkpro-core-maltparser-asl/pom.xml
+++ b/dkpro-core-maltparser-asl/pom.xml
@@ -28,7 +28,7 @@
   <name>DKPro Core ASL - MaltParser (v ${maltparser.version})</name>
   <url>https://dkpro.github.io/dkpro-core/</url>
   <properties>
-    <maltparser.version>1.9.1</maltparser.version>
+    <maltparser.version>1.9.2</maltparser.version>
   </properties>
   <dependencies>
     <dependency>

--- a/dkpro-core-maltparser-asl/pom.xml
+++ b/dkpro-core-maltparser-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-maltparser-asl</artifactId>
@@ -166,14 +166,14 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-hunpos-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/dkpro-core-matetools-gpl/pom.xml
+++ b/dkpro-core-matetools-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <artifactId>dkpro-core-matetools-gpl</artifactId>
@@ -141,7 +141,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-hunpos-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/dkpro-core-maui-gpl/pom.xml
+++ b/dkpro-core-maui-gpl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/dkpro-core-mecab-asl/pom.xml
+++ b/dkpro-core-mecab-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-mecab-asl</artifactId>

--- a/dkpro-core-morpha-asl/pom.xml
+++ b/dkpro-core-morpha-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-morpha-asl</artifactId>
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/dkpro-core-mstparser-asl/pom.xml
+++ b/dkpro-core-mstparser-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-mstparser-asl</artifactId>
@@ -131,7 +131,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-hunpos-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-mystem-asl/pom.xml
+++ b/dkpro-core-mystem-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-mystem-asl</artifactId>

--- a/dkpro-core-ngrams-asl/pom.xml
+++ b/dkpro-core-ngrams-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-ngrams-asl</artifactId>

--- a/dkpro-core-nlp4j-asl/pom.xml
+++ b/dkpro-core-nlp4j-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-nlp4j-asl</artifactId>

--- a/dkpro-core-norvig-asl/pom.xml
+++ b/dkpro-core-norvig-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-norvig-asl</artifactId>

--- a/dkpro-core-opennlp-asl/pom.xml
+++ b/dkpro-core-opennlp-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-opennlp-asl</artifactId>

--- a/dkpro-core-performance-asl/pom.xml
+++ b/dkpro-core-performance-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-performance-asl</artifactId>
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-posfilter-asl/pom.xml
+++ b/dkpro-core-posfilter-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-posfilter-asl</artifactId>
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-readability-asl/pom.xml
+++ b/dkpro-core-readability-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-readability-asl</artifactId>

--- a/dkpro-core-rftagger-asl/pom.xml
+++ b/dkpro-core-rftagger-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-rftagger-asl</artifactId>

--- a/dkpro-core-sfst-gpl/pom.xml
+++ b/dkpro-core-sfst-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <artifactId>dkpro-core-sfst-gpl</artifactId>

--- a/dkpro-core-smile-asl/pom.xml
+++ b/dkpro-core-smile-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-smile-asl</artifactId>
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-smile-asl/pom.xml
+++ b/dkpro-core-smile-asl/pom.xml
@@ -29,7 +29,7 @@
   <url>https://dkpro.github.io/dkpro-core/</url>
   <description>http://haifengl.github.io/smile</description>
   <properties>
-    <smile.version>1.3.1</smile.version>
+    <smile.version>2.3.0</smile.version>
   </properties>
   <dependencies>
     <dependency>

--- a/dkpro-core-snowball-asl/pom.xml
+++ b/dkpro-core-snowball-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-snowball-asl</artifactId>
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-stanfordnlp-gpl/pom.xml
+++ b/dkpro-core-stanfordnlp-gpl/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.googlecode.efficient-java-matrix-library</groupId>
       <artifactId>ejml</artifactId>
-      <version>0.23</version>
+      <version>0.25</version>
     </dependency>
     <dependency>
       <groupId>edu.stanford.nlp</groupId>
@@ -267,7 +267,7 @@
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
         <artifactId>de.tudarmstadt.ukp.dkpro.core.stanfordnlp-model-parser-ar-sr</artifactId>
-        <version>20141031.1</version>
+        <version>20180227.1</version>
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
@@ -397,7 +397,7 @@
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
         <artifactId>de.tudarmstadt.ukp.dkpro.core.stanfordnlp-model-tagger-en-wsj-0-18-left3words-distsim</artifactId>
-        <version>20131112.1</version>
+        <version>20140616.1</version>
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>

--- a/dkpro-core-stanfordnlp-gpl/pom.xml
+++ b/dkpro-core-stanfordnlp-gpl/pom.xml
@@ -53,7 +53,8 @@
     <dependency>
       <groupId>com.googlecode.efficient-java-matrix-library</groupId>
       <artifactId>ejml</artifactId>
-      <version>0.25</version>
+      <!-- CAUTION: Upgrade to newer version breaks deserialization of coref models -->
+      <version>0.23</version>
     </dependency>
     <dependency>
       <groupId>edu.stanford.nlp</groupId>

--- a/dkpro-core-stanfordnlp-gpl/pom.xml
+++ b/dkpro-core-stanfordnlp-gpl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-gpl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-gpl</relativePath>
   </parent>
   <artifactId>dkpro-core-stanfordnlp-gpl</artifactId>

--- a/dkpro-core-testing-asl/pom.xml
+++ b/dkpro-core-testing-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-testing-asl</artifactId>

--- a/dkpro-core-textcat-asl/pom.xml
+++ b/dkpro-core-textcat-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-textcat-asl</artifactId>

--- a/dkpro-core-textnormalizer-asl/pom.xml
+++ b/dkpro-core-textnormalizer-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-textnormalizer-asl</artifactId>
@@ -147,7 +147,7 @@
       <dependency>
         <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-opennlp-asl</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/dkpro-core-tokit-asl/pom.xml
+++ b/dkpro-core-tokit-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-tokit-asl</artifactId>

--- a/dkpro-core-treetagger-asl/pom.xml
+++ b/dkpro-core-treetagger-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>dkpro-core-asl</artifactId>
     <groupId>org.dkpro.core</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-treetagger-asl</artifactId>

--- a/dkpro-core-udpipe-asl/pom.xml
+++ b/dkpro-core-udpipe-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.core</groupId>
     <artifactId>dkpro-core-asl</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <relativePath>../dkpro-core-asl</relativePath>
   </parent>
   <artifactId>dkpro-core-udpipe-asl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <groupId>org.dkpro.core</groupId>
   <artifactId>dkpro-core</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>DKPro Core</name>
   <!-- The description tag must be present for antrun to work!! -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro</groupId>
     <artifactId>dkpro-parent-pom</artifactId>
-    <version>23</version>
+    <version>24-SNAPSHOT</version>
   </parent>
   <groupId>org.dkpro.core</groupId>
   <artifactId>dkpro-core</artifactId>
@@ -45,11 +45,12 @@
     <lucene.version>4.4.0</lucene.version>
     <!-- The Spring version should be at least whatever uimaFIT requires -->
     <spring.version>4.3.26.RELEASE</spring.version>
-    <slf4j.version>1.7.26</slf4j.version>
-    <log4j.version>2.7</log4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
+    <log4j.version>2.13.1</log4j.version>
     <maven.surefire.heap>6g</maven.surefire.heap>
     <activation.version>1.2.0</activation.version>
-    <icu4j.version>64.2</icu4j.version>
+    <icu4j.version>66.1</icu4j.version>
+    <snakeyaml.version>1.26</snakeyaml.version>
   </properties>
   <repositories>
     <repository>
@@ -198,12 +199,12 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <version>4.13</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.9.1</version>
+        <version>3.15.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.uima</groupId>
@@ -243,7 +244,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.24</version>
+        <version>${snakeyaml.version}</version>
       </dependency>
       <dependency>
         <groupId>xerces</groupId>
@@ -313,12 +314,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.3</version>
+        <version>4.4</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.12</version>
+        <version>1.14</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -333,12 +334,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.9</version>
+        <version>3.10</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.19</version>
+        <version>1.20</version>
       </dependency>
       <dependency>
         <groupId>org.tukaani</groupId>
@@ -348,7 +349,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.10.5</version>
+        <version>1.10.7</version>
       </dependency>
       <dependency>
         <groupId>jaxen</groupId>
@@ -445,6 +446,11 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.2</version>
@@ -457,12 +463,12 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-        <version>8.2.2</version>
+        <version>8.3.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ivy</groupId>
         <artifactId>ivy</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>eu.openminted.share.annotations</groupId>
@@ -492,17 +498,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.10</version>
+        <version>2.10.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.10</version>
+        <version>2.10.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.10.3</version>
+        <version>2.10.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -714,6 +720,21 @@
               <uima.v2_pretty_print_format>true</uima.v2_pretty_print_format>
             </systemPropertyVariables>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.7</version>
+          <configuration>
+            <rulesUri>file:${session.executionRootDirectory}/dkpro-core-build/src/main/resources/dkpro-core/version-rules.xml</rulesUri>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.dkpro.core</groupId>
+              <artifactId>dkpro-core-build</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,13 @@
   <properties>
     <currentYear>2019</currentYear>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-    <uima.version>3.1.0</uima.version>
-    <uimafit.version>3.0.0</uimafit.version>
-    <uimafit.plugin.version>3.0.0</uimafit.plugin.version>
+    <uima.version>3.1.1</uima.version>
+    <uimafit.version>3.1.0-SNAPSHOT</uimafit.version>
+    <uimafit.plugin.version>3.1.0-SNAPSHOT</uimafit.plugin.version>
     <omtd.version>3.0.2.7</omtd.version>
     <lucene.version>4.4.0</lucene.version>
     <!-- The Spring version should be at least whatever uimaFIT requires -->
-    <spring.version>4.3.22.RELEASE</spring.version>
+    <spring.version>4.3.26.RELEASE</spring.version>
     <slf4j.version>1.7.26</slf4j.version>
     <log4j.version>2.7</log4j.version>
     <maven.surefire.heap>6g</maven.surefire.heap>
@@ -81,7 +81,7 @@
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
-      <url>http://repository.apache.org/snapshots</url>
+      <url>https://repository.apache.org/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -93,7 +93,7 @@
     <!--
     <repository>
       <id>ukp-oss-snapshots</id>
-      <url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots</url>
+      <url>https://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -133,7 +133,7 @@
     <pluginRepository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
-      <url>http://repository.apache.org/snapshots</url>
+      <url>https://repository.apache.org/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -805,13 +805,11 @@
     </profile>
     <profile>
       <id>checkstyle</id>
-      <!--  
       <activation>
         <file>
           <exists>src</exists>
         </file>
       </activation>
-      -->
       <build>
         <plugins>
           <plugin>
@@ -824,7 +822,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-checkstyle-plugin</artifactId>
-              <version>3.1.0</version>
+              <version>3.1.1</version>
               <inherited>true</inherited>
               <dependencies>
                 <dependency>
@@ -835,7 +833,7 @@
                 <dependency>
                   <groupId>com.puppycrawl.tools</groupId>
                   <artifactId>checkstyle</artifactId>
-                  <version>8.29</version>
+                  <version>8.31</version>
                 </dependency>
               </dependencies>
               <configuration>


### PR DESCRIPTION
**Components**
- Updated jtok 2.1.18 -> 2.1.19
- Updated ixa-pipe-pos 1.5.1 -> 1.5.3
- Updated LanguageTool 4.3 -> 4.9
- Updated LingPipe 4.1.0 -> 4.1.2-JL1.0
- Updated MaltParser 1.9.1 -> 1.9.2
- Updated SMILE 1.3.1 -> 2.3.0
- Updated ICU 64.2 -> 66.1

**Models**
- Updated model dependencies in dkpro-core-corenlp-gpl
- Updated model dependencies in dkpro-core-stanfordnlp-gpl

**IO Formats**
- Updated wlfxb 1.4.2 -> 1.4.3
- Updated pdfbox 2.0.12 -> 2.0.19

**Other dependencies**
- Updated DKPro Parent POM 23- > 24-SNAPSHOT **FIXME**
- Updated UIMA 3.1.0 -> 3.1.1
- Updated uimaFIT 3.0.0 -> 3.1.0-SNAPSHOT **FIXME**
- Updated Spring 4.3.22 -> 4.3.26
- Updated snakeyml 1.19 ->  1.26
- Updated hsqldb 2.3.2 -> 2.5.0
- Updated jena 3.5.0 -> 3.14.0
- Updated slf4j 1.7.26 -> 1.7.30
- Updated log4j 2.7 -> 2.13.1
- Updated JUnit 4.12 -> 4.13
- Updated assertj 3.9.1 -> 3.15.0

**Other changes**
- Updated Maven Checkstyle Plugin 3.1.0 -> 3.1.1
- Updated Checkstyle 8.29 -> 8.31
- Use https instead of http for Maven repos
- Fix a couple of checkstyle suppression files
- Set versions in some modules that are excluded from the release
- Set version to 2.2.0-SNAPSHOT
- Demote log message about loaded datasets to trace level
- Demote some resource loading log messages to trace and debug level
- Added version checking rules