### PR TITLE
#1539 - Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <activation.version>1.2.0</activation.version>
     <groovy.version>3.0.10</groovy.version>
     <icu4j.version>68.2</icu4j.version>
-    <jackson.version>2.14.0</jackson.version>
+    <jackson.version>2.14.1</jackson.version>
     <jena.version>4.6.1</jena.version>
     <log4j.version>2.17.2</log4j.version>
     <lucene.version>4.4.0</lucene.version>
@@ -53,7 +53,7 @@
     <slf4j.version>1.7.36</slf4j.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <!-- The Spring version should be at least whatever uimaFIT requires -->
-    <spring.version>5.3.23</spring.version>
+    <spring.version>5.3.24</spring.version>
     <uima.version>3.3.1</uima.version>
     <uimafit.version>3.3.0</uimafit.version>
     <uimafit.plugin.version>${uimafit.version}</uimafit.plugin.version>
@@ -66,83 +66,7 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <!-- For UIMA/uimaFIT RCs -->
-    <!--
-    <repository>
-      <id>ext-staging</id>
-      <name>Staging repo</name>
-      <url>https://repository.apache.org/content/repositories/orgapacheuima-1205/</url>
-      <releases>
-          <enabled>true</enabled>
-      </releases>
-    </repository>
-    -->
-    <!-- For UIMA/uimaFIT SNAPSHOT
-    <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    -->
-    <!-- For SNAPSHOTs from the DKPro family -->
-    <!--
-    <repository>
-      <id>ukp-oss-snapshots</id>
-      <url>https://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    -->
   </repositories>
-  <pluginRepositories>
-    <!-- For UIMA/uimaFIT RCs -->
-    <!--
-    <pluginRepository>
-      <id>ext-staging</id>
-      <name>Staging repo</name>
-      <url>https://repository.apache.org/content/repositories/orgapacheuima-1205/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </pluginRepository>
-    -->
-    <!-- For UIMA/uimaFIT SNAPSHOT maven plugin -->
-    <pluginRepository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-    <!-- For SNAPSHOTs from OpenMinTeD -->
-    <!--  
-    <pluginRepository>
-      <id>omtd-snapshots</id>
-      <layout>default</layout>
-      <url>https://repo.openminted.eu/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-    -->
-  </pluginRepositories>
   <mailingLists>
     <mailingList>
       <name>DKPro Core user mailing list</name>
@@ -190,12 +114,12 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.22.0</version>
+        <version>3.23.1</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>4.8.1</version>
+        <version>4.11.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -339,7 +263,7 @@
       <dependency>
         <groupId>org.tukaani</groupId>
         <artifactId>xz</artifactId>
-        <version>1.8</version>
+        <version>1.9</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ant</groupId>
@@ -453,7 +377,7 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-        <version>8.4.4</version>
+        <version>8.5.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ivy</groupId>


### PR DESCRIPTION
- jackson 2.14.0 -> 2.14.1
- spring 5.3.23 -> 5.3.24
- assertj 3.22.0 -> 3.23.1
- mockito 4.8.1 -> 4.11.0
- xz 1.8 -> 1.9
- fastutil 8.4.4 -> 8.5.11