### PR TITLE
#1570 - Support xml id on certain TEI elements

### DIFF
--- a/dkpro-core-io-tei-asl/src/main/java/org/dkpro/core/io/tei/TeiWriter.java
+++ b/dkpro-core-io-tei-asl/src/main/java/org/dkpro/core/io/tei/TeiWriter.java
@@ -20,6 +20,7 @@ package org.dkpro.core.io.tei;
 import static org.dkpro.core.io.tei.internal.TeiConstants.ATTR_FUNCTION;
 import static org.dkpro.core.io.tei.internal.TeiConstants.ATTR_LEMMA;
 import static org.dkpro.core.io.tei.internal.TeiConstants.ATTR_TYPE;
+import static org.dkpro.core.io.tei.internal.TeiConstants.ATTR_XML_ID;
 import static org.dkpro.core.io.tei.internal.TeiConstants.E_TEI_BODY;
 import static org.dkpro.core.io.tei.internal.TeiConstants.E_TEI_FILE_DESC;
 import static org.dkpro.core.io.tei.internal.TeiConstants.E_TEI_HEADER;
@@ -64,6 +65,7 @@ import org.dkpro.core.api.parameter.MimeTypes;
 
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Div;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
@@ -141,10 +143,10 @@ public class TeiWriter
 
         XMLEventWriter xmlEventWriter = null;
         try (OutputStream docOS = getOutputStream(aJCas, filenameSuffix)) {
-            
+
             XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
             xmlOutputFactory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, true);
-            
+
             xmlEventWriter = xmlOutputFactory.createXMLEventWriter(docOS, "UTF-8");
             if (indent) {
                 xmlEventWriter = new IndentingXMLEventWriter(xmlEventWriter);
@@ -266,12 +268,27 @@ public class TeiWriter
     private Iterator<Attribute> getAttributes(Annotation aAnnotation) {
         List<Attribute> attributes = new ArrayList<Attribute>();
         if (aAnnotation instanceof Token) {
-            Token t = (Token) aAnnotation;
+            var t = (Token) aAnnotation;
+            if (t.getId() != null) {
+                attributes.add(xmlef.createAttribute(ATTR_XML_ID, t.getId()));
+            }
             if (t.getPos() != null && t.getPos().getPosValue() != null) {
                 attributes.add(xmlef.createAttribute(ATTR_TYPE, t.getPos().getPosValue()));
             }
             if (t.getLemma() != null && t.getLemma().getValue() != null) {
                 attributes.add(xmlef.createAttribute(ATTR_LEMMA, t.getLemma().getValue()));
+            }
+        }
+        else if (aAnnotation instanceof Sentence) {
+            var s = (Sentence) aAnnotation;
+            if (s.getId() != null) {
+                attributes.add(xmlef.createAttribute(ATTR_XML_ID, s.getId()));
+            }
+        }
+        else if (aAnnotation instanceof Div) {
+            var div = (Div) aAnnotation;
+            if (div.getId() != null) {
+                attributes.add(xmlef.createAttribute(ATTR_XML_ID, div.getId()));
             }
         }
         else if (aAnnotation instanceof NamedEntity) {

--- a/dkpro-core-io-tei-asl/src/main/java/org/dkpro/core/io/tei/internal/TeiConstants.java
+++ b/dkpro-core-io-tei-asl/src/main/java/org/dkpro/core/io/tei/internal/TeiConstants.java
@@ -80,6 +80,7 @@ public final class TeiConstants
     public static final String ATTR_FUNCTION = "function";
     public static final String ATTR_LEMMA = "lemma";
 
+    public static final String ATTR_XML_ID = "xml:id";
     
     public static final String TEI_NS = "http://www.tei-c.org/ns/1.0";
     public static final QName E_TEI_TEI = new QName(TEI_NS, TAG_TEI_DOC);

--- a/dkpro-core-io-tei-asl/src/test/java/org/dkpro/core/io/tei/TeiReaderTest.java
+++ b/dkpro-core-io-tei-asl/src/test/java/org/dkpro/core/io/tei/TeiReaderTest.java
@@ -76,6 +76,22 @@ public class TeiReaderTest
     }
 
     @Test
+    void thatXmlIdsArePreserved(@TempDir File tempDir) throws Exception
+    {
+        var x = ReaderAssert.assertThat(//
+                TeiReader.class, //
+                TeiReader.PARAM_LANGUAGE, "en", //
+                TeiReader.PARAM_SOURCE_LOCATION, "classpath:/with_xml_id/input.xml")//
+                .usingWriter(//
+                        TeiWriter.class, TeiWriter.PARAM_OVERWRITE, true)
+                .writingTo(tempDir);//
+        x.outputAsString()//
+                .isEqualToNormalizingNewlines(contentOf(
+                        new File("src/test/resources/with_xml_id/input-ref.xml"),
+                        UTF_8));
+    }
+
+    @Test
     public void thatBrownCorpusIsReadCorrectly() throws Exception
     {
         ReaderAssert.assertThat(//

--- a/dkpro-core-io-tei-asl/src/test/java/org/dkpro/core/io/tei/TeiWriterTest.java
+++ b/dkpro-core-io-tei-asl/src/test/java/org/dkpro/core/io/tei/TeiWriterTest.java
@@ -24,14 +24,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
-import org.apache.uima.analysis_engine.AnalysisEngineDescription;
-import org.apache.uima.collection.CollectionReaderDescription;
 import org.dkpro.core.io.text.TextReader;
 import org.dkpro.core.opennlp.OpenNlpNamedEntityRecognizer;
 import org.dkpro.core.opennlp.OpenNlpParser;
 import org.dkpro.core.opennlp.OpenNlpPosTagger;
 import org.dkpro.core.opennlp.OpenNlpSegmenter;
-import org.dkpro.core.testing.dumper.CasDumpWriter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -41,30 +38,30 @@ public class TeiWriterTest
     public void test(@TempDir File targetFolder)
         throws Exception
     {
-        CollectionReaderDescription textReader = createReaderDescription(
+        var textReader = createReaderDescription(
                 TextReader.class,
                 TextReader.PARAM_LANGUAGE, "en",
                 TextReader.PARAM_SOURCE_LOCATION, "src/test/resources/texts",
                 TextReader.PARAM_PATTERNS, "*.txt");
 
-        AnalysisEngineDescription segmenter = createEngineDescription(OpenNlpSegmenter.class);
+        var segmenter = createEngineDescription(OpenNlpSegmenter.class);
 
-        AnalysisEngineDescription posTagger = createEngineDescription(OpenNlpPosTagger.class);
+        var posTagger = createEngineDescription(OpenNlpPosTagger.class);
 
-        AnalysisEngineDescription parser = createEngineDescription(OpenNlpParser.class);
+        var parser = createEngineDescription(OpenNlpParser.class);
 
-        AnalysisEngineDescription ner = createEngineDescription(OpenNlpNamedEntityRecognizer.class);
+        var ner = createEngineDescription(OpenNlpNamedEntityRecognizer.class);
 
-        AnalysisEngineDescription dump = createEngineDescription(CasDumpWriter.class);
+//        var dump = createEngineDescription(CasDumpWriter.class);
 
-        AnalysisEngineDescription teiWriter = createEngineDescription(
+        var teiWriter = createEngineDescription(
                 TeiWriter.class,
                 TeiWriter.PARAM_TARGET_LOCATION, targetFolder,
                 TeiWriter.PARAM_WRITE_CONSTITUENT, true);
 
-        runPipeline(textReader, segmenter, posTagger, parser, ner, dump, teiWriter);
+        runPipeline(textReader, segmenter, posTagger, parser, ner, teiWriter);
 
-        File output = new File(targetFolder, "example1.txt.xml");
+        var output = new File(targetFolder, "example1.txt.xml");
         assertTrue(output.exists());
 
 //        Diff myDiff = new Diff(

--- a/dkpro-core-io-tei-asl/src/test/resources/with_xml_id/input-ref.xml
+++ b/dkpro-core-io-tei-asl/src/test/resources/with_xml_id/input-ref.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0"><teiHeader><fileDesc><titleStmt><title>input.xml</title></titleStmt></fileDesc></teiHeader><text><body>
+    
+      
+        
+          <s xml:id="s1"><p xml:id="p1"><w xml:id="t1">This</w>
+          <w xml:id="t2">is</w>
+          <w xml:id="t3">a</w>
+          <w xml:id="t4">test</w>
+          <c xml:id="t5">.</c></p></s>
+        
+      
+      
+        
+          <s xml:id="s2"><p xml:id="p2"><w xml:id="t6">This</w>
+          <w xml:id="t7">is</w>
+          <w xml:id="t8">a</w>
+          <w xml:id="t9">test</w>
+          <c xml:id="t10">.</c></p></s>
+        
+      
+    
+  </body></text></TEI>

--- a/dkpro-core-io-tei-asl/src/test/resources/with_xml_id/input.xml
+++ b/dkpro-core-io-tei-asl/src/test/resources/with_xml_id/input.xml
@@ -1,0 +1,24 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <text xml:id="doc1">
+    <body>
+      <p xml:id="p1">
+        <s xml:id="s1">
+          <w xml:id="t1">This</w>
+          <w xml:id="t2">is</w>
+          <w xml:id="t3">a</w>
+          <w xml:id="t4">test</w>
+          <c xml:id="t5">.</c>
+        </s>
+      </p>
+      <p xml:id="p2">
+        <s xml:id="s2">
+          <w xml:id="t6">This</w>
+          <w xml:id="t7">is</w>
+          <w xml:id="t8">a</w>
+          <w xml:id="t9">test</w>
+          <c xml:id="t10">.</c>
+        </s>
+      </p>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
**What's in the PR**
- Preserve xml:ids on sentence, paragraph and token

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
