### PR TITLE
#1602 - Upgrade dependencies

### DIFF
--- a/dkpro-core-api-datasets-asl/pom.xml
+++ b/dkpro-core-api-datasets-asl/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.github.junrar</groupId>
       <artifactId>junrar</artifactId>
-      <version>7.5.7</version>
+      <version>7.5.10</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.commons</groupId>

--- a/dkpro-core-bom/pom.xml
+++ b/dkpro-core-bom/pom.xml
@@ -42,7 +42,7 @@
       <plugin>
         <groupId>eu.maveniverse.maven.plugins</groupId>
         <artifactId>bom-builder3</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.3</version>
         <executions>
           <execution>
             <id>build-bom</id>

--- a/dkpro-core-commonscodec-asl/src/test/java/org/dkpro/core/commonscodec/ColognePhoneticTranscriptorTest.java
+++ b/dkpro-core-commonscodec-asl/src/test/java/org/dkpro/core/commonscodec/ColognePhoneticTranscriptorTest.java
@@ -30,7 +30,7 @@ public class ColognePhoneticTranscriptorTest
     {
 
         runTest(createEngineDescription(ColognePhoneticTranscriptor.class),
-                "Man sagt die Ente ist das Ende vom Mann .", "66", "842", "2", "062", "082", "28",
-                "062", "36", "66", "");
+                "Man sagt die Ente ist das Ende vom Mann .", "6", "842", "2", "062", "082", "28",
+                "062", "36", "6", "");
     }
 }

--- a/dkpro-core-io-html-asl/pom.xml
+++ b/dkpro-core-io-html-asl/pom.xml
@@ -30,7 +30,7 @@
   <url>https://dkpro.github.io/dkpro-core/</url>
 
   <properties>
-    <jsoup.version>1.22.1</jsoup.version>
+    <jsoup.version>1.22.2</jsoup.version>
   </properties>
 
   <dependencies>

--- a/dkpro-core-io-jwpl-asl/pom.xml
+++ b/dkpro-core-io-jwpl-asl/pom.xml
@@ -30,7 +30,7 @@
   <url>https://dkpro.github.io/dkpro-core/</url>
 
   <properties>
-    <jwpl.version>2.0.1</jwpl.version>
+    <jwpl.version>2.0.2</jwpl.version>
   </properties>
 
   <dependencies>

--- a/dkpro-core-io-pdf-asl/pom.xml
+++ b/dkpro-core-io-pdf-asl/pom.xml
@@ -30,7 +30,7 @@
   <url>https://dkpro.github.io/dkpro-core/</url>
 
   <properties>
-    <pdfbox.version>3.0.6</pdfbox.version>
+    <pdfbox.version>3.0.7</pdfbox.version>
   </properties>
 
   <dependencies>

--- a/dkpro-core-io-tika-asl/pom.xml
+++ b/dkpro-core-io-tika-asl/pom.xml
@@ -30,7 +30,7 @@
   <url>https://dkpro.github.io/dkpro-core/</url>
 
   <properties>
-    <tika.version>3.2.3</tika.version>
+    <tika.version>3.3.0</tika.version>
   </properties>
 
   <dependencies>

--- a/dkpro-core-languagetool-asl/pom.xml
+++ b/dkpro-core-languagetool-asl/pom.xml
@@ -31,7 +31,7 @@
   <description>Grammar checker based on LanguageTool (LGPL)</description>
 
   <properties>
-    <languagetool.version>6.7</languagetool.version>
+    <languagetool.version>6.8</languagetool.version>
   </properties>
 
   <dependencies>

--- a/dkpro-core-opennlp-asl/pom.xml
+++ b/dkpro-core-opennlp-asl/pom.xml
@@ -31,7 +31,7 @@
   <url>https://dkpro.github.io/dkpro-core/</url>
 
   <properties>
-    <opennlp.version>2.5.7</opennlp.version>
+    <opennlp.version>2.5.9</opennlp.version>
   </properties>
 
   <dependencies>

--- a/dkpro-core-parent-common/pom.xml
+++ b/dkpro-core-parent-common/pom.xml
@@ -33,25 +33,25 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     <maven.surefire.heap>6g</maven.surefire.heap>
 
-    <junit-jupiter.version>6.0.1</junit-jupiter.version>
-    <junit-platform.version>6.0.1</junit-platform.version>
-    <mockito.version>5.21.0</mockito.version>
-    <assertj.version>3.27.6</assertj.version>
+    <junit-jupiter.version>6.0.3</junit-jupiter.version>
+    <junit-platform.version>6.0.3</junit-platform.version>
+    <mockito.version>5.23.0</mockito.version>
+    <assertj.version>3.27.7</assertj.version>
     <xmlunit.version>2.11.0</xmlunit.version>
 
     <ant-version>1.10.15</ant-version>
     <activation.version>1.2.0</activation.version>
-    <groovy.version>5.0.3</groovy.version>
-    <icu4j.version>78.1</icu4j.version>
-    <jackson.version>2.20.1</jackson.version>
+    <groovy.version>5.0.6</groovy.version>
+    <icu4j.version>78.3</icu4j.version>
+    <jackson.version>2.21.3</jackson.version>
     <jena.version>5.6.0</jena.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.26.0</log4j.version>
     <lucene.version>4.4.0</lucene.version>
     <omtd.version>3.0.2.7</omtd.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <snakeyaml.version>2.5</snakeyaml.version>
+    <snakeyaml.version>2.6</snakeyaml.version>
     <!-- The Spring version should be at least whatever uimaFIT requires -->
-    <spring.version>7.0.2</spring.version>
+    <spring.version>7.0.7</spring.version>
     <uima.version>3.6.1</uima.version>
     <uimafit.plugin.version>${uima.version}</uimafit.plugin.version>
   </properties>
@@ -251,12 +251,12 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.20.0</version>
+        <version>1.22.0</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>
@@ -281,7 +281,7 @@
       <dependency>
         <groupId>org.tukaani</groupId>
         <artifactId>xz</artifactId>
-        <version>1.11</version>
+        <version>1.12</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ant</groupId>
@@ -291,7 +291,7 @@
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <exclusions>
           <exclusion>
             <artifactId>dom4j</artifactId>
@@ -326,7 +326,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.5.0-jre</version>
+        <version>33.6.0-jre</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -385,7 +385,7 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.3.5</version>
+        <version>1.3.6</version>
       </dependency>
       <dependency>
         <groupId>it.unimi.dsi</groupId>
@@ -430,12 +430,12 @@
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,12 @@
   
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
-    <build-ant-version>1.10.15</build-ant-version>
-    <build-groovy-version>5.0.3</build-groovy-version>
+    <build-ant-version>1.10.17</build-ant-version>
+    <build-groovy-version>5.0.6</build-groovy-version>
     <build-asciidoctorj-pdf-version>2.3.23</build-asciidoctorj-pdf-version>
     <!-- Plugin versions managed centrally -->
-    <versions.plugin.version>2.20.1</versions.plugin.version>
-    <gmavenplus.plugin.version>4.2.1</gmavenplus.plugin.version>
+    <versions.plugin.version>2.21.0</versions.plugin.version>
+    <gmavenplus.plugin.version>4.3.1</gmavenplus.plugin.version>
     <spdx.plugin.version>1.0.3</spdx.plugin.version>
     <license.plugin.version>5.0.0</license.plugin.version>
     <maven.checkstyle.plugin.version>3.6.0</maven.checkstyle.plugin.version>
@@ -113,7 +113,7 @@
         <plugin>
           <groupId>com.rudikershaw.gitbuildhook</groupId>
           <artifactId>git-build-hook-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
**What's in the PR**
- junit-jupiter 6.0.1 -> 6.0.3
- junit-platform 6.0.1 -> 6.0.3
- mockito 5.21.0 -> 5.23.0
- assertj 3.27.6 -> 3.27.7
- groovy 5.0.3 -> 5.0.6
- icu4j 78.1 -> 78.3
- jackson 2.20.1 -> 2.21.3
- log4j 2.25.3 -> 2.26.0
- snakeyaml 2.5 -> 2.6
- spring 7.0.2 -> 7.0.7
- guava 33.5.0 -> 33.6.0
- xz 1.11 -> 1.12
- commons-codec 1.20.0 -> 1.22.0
- commons-io 2.21.0 -> 2.22.0
- commons-logging 1.3.5 -> 1.3.6
- jaxen 2.0.0 -> 2.0.1
- jakarta.xml.bind-api 4.0.4 -> 4.0.5
- jaxb-runtime 4.0.5 -> 4.0.8
- ant 1.10.15 -> 1.10.17
- opennlp 2.5.7 -> 2.5.9
- junrar 7.5.7 -> 7.5.10
- pdfbox 3.0.6 -> 3.0.7
- tika 3.2.3 -> 3.3.0
- jsoup 1.22.1 -> 1.22.2
- languagetool 6.7 -> 6.8
- jwpl 2.0.1 -> 2.0.2
- gmavenplus-plugin 4.2.1 -> 4.3.1
- versions-maven-plugin 2.20.1 -> 2.21.0
- git-build-hook-maven-plugin 3.5.0 -> 3.6.0
- bom-builder3 1.3.1 -> 1.3.3

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
