### PR TITLE
#1623 - Reader and writer for UIMA JSON CAS format

### DIFF
--- a/dkpro-core-io-json-asl/pom.xml
+++ b/dkpro-core-io-json-asl/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>uimafit-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-io-json</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/dkpro-core-io-json-asl/src/main/java/org/dkpro/core/io/json/JsonCasReader.java
+++ b/dkpro-core-io-json-asl/src/main/java/org/dkpro/core/io/json/JsonCasReader.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.io.json;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.json.jsoncas2.JsonCas2Deserializer;
+import org.apache.uima.json.jsoncas2.mode.FeatureStructuresMode;
+import org.dkpro.core.api.io.JCasResourceCollectionReader_ImplBase;
+import org.dkpro.core.api.parameter.MimeTypes;
+
+import eu.openminted.share.annotations.api.DocumentationResource;
+
+/**
+ * Reader for the UIMA JSON CAS 2 format produced by the {@code uimaj-io-json} module.
+ */
+@ResourceMetaData(name = "UIMA JSON CAS Reader")
+@DocumentationResource("${docbase}/format-reference.html#format-${command}")
+@MimeTypeCapability({ MimeTypes.APPLICATION_X_UIMA_JSON })
+public class JsonCasReader
+    extends JCasResourceCollectionReader_ImplBase
+{
+    /**
+     * Whether feature structures are encoded as JSON arrays or JSON objects in the input.
+     */
+    public static final String PARAM_FEATURE_STRUCTURES_MODE = "featureStructuresMode";
+    @ConfigurationParameter(name = PARAM_FEATURE_STRUCTURES_MODE, mandatory = true, defaultValue = "AS_ARRAY")
+    private FeatureStructuresMode featureStructuresMode;
+
+    @Override
+    public void getNext(JCas aJCas) throws IOException, CollectionException
+    {
+        Resource res = nextFile();
+        initCas(aJCas, res);
+
+        var deserializer = new JsonCas2Deserializer();
+        deserializer.setFsMode(featureStructuresMode);
+
+        try (InputStream is = res.getInputStream()) {
+            deserializer.deserialize(is, aJCas.getCas());
+        }
+    }
+}

--- a/dkpro-core-io-json-asl/src/main/java/org/dkpro/core/io/json/JsonCasWriter.java
+++ b/dkpro-core-io-json-asl/src/main/java/org/dkpro/core/io/json/JsonCasWriter.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.io.json;
+
+import java.io.OutputStream;
+
+import org.apache.uima.UimaContext;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.json.jsoncas2.JsonCas2Serializer;
+import org.apache.uima.json.jsoncas2.mode.FeatureStructuresMode;
+import org.apache.uima.json.jsoncas2.mode.OffsetConversionMode;
+import org.apache.uima.json.jsoncas2.mode.SofaMode;
+import org.apache.uima.json.jsoncas2.mode.TypeSystemMode;
+import org.apache.uima.json.jsoncas2.ref.FullyQualifiedTypeRefGenerator;
+import org.apache.uima.json.jsoncas2.ref.SequentialIdRefGenerator;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.dkpro.core.api.io.JCasFileWriter_ImplBase;
+import org.dkpro.core.api.parameter.MimeTypes;
+
+import eu.openminted.share.annotations.api.DocumentationResource;
+
+/**
+ * Writer for the UIMA JSON CAS 2 format produced by the {@code uimaj-io-json} module.
+ */
+@ResourceMetaData(name = "UIMA JSON CAS Writer")
+@DocumentationResource("${docbase}/format-reference.html#format-${command}")
+@MimeTypeCapability({ MimeTypes.APPLICATION_X_UIMA_JSON })
+public class JsonCasWriter
+    extends JCasFileWriter_ImplBase
+{
+    /**
+     * Whether feature structures are encoded as JSON arrays or JSON objects.
+     */
+    public static final String PARAM_FEATURE_STRUCTURES_MODE = "featureStructuresMode";
+    @ConfigurationParameter(name = PARAM_FEATURE_STRUCTURES_MODE, mandatory = true, defaultValue = "AS_ARRAY")
+    private FeatureStructuresMode featureStructuresMode;
+
+    /**
+     * How to represent the SOFA in the output.
+     */
+    public static final String PARAM_SOFA_MODE = "sofaMode";
+    @ConfigurationParameter(name = PARAM_SOFA_MODE, mandatory = true, defaultValue = "AS_REGULAR_FEATURE_STRUCTURE")
+    private SofaMode sofaMode;
+
+    /**
+     * Offset units used for annotation begin/end values.
+     */
+    public static final String PARAM_OFFSET_CONVERSION_MODE = "offsetConversionMode";
+    @ConfigurationParameter(name = PARAM_OFFSET_CONVERSION_MODE, mandatory = true, defaultValue = "UTF_16")
+    private OffsetConversionMode offsetConversionMode;
+
+    /**
+     * How much of the type system to include in the output.
+     */
+    public static final String PARAM_TYPE_SYSTEM_MODE = "typeSystemMode";
+    @ConfigurationParameter(name = PARAM_TYPE_SYSTEM_MODE, mandatory = true, defaultValue = "MINIMAL")
+    private TypeSystemMode typeSystemMode;
+
+    private JsonCas2Serializer serializer;
+
+    @Override
+    public void initialize(UimaContext aContext) throws ResourceInitializationException
+    {
+        super.initialize(aContext);
+
+        serializer = new JsonCas2Serializer();
+        serializer.setFsMode(featureStructuresMode);
+        serializer.setSofaMode(sofaMode);
+        serializer.setOffsetConversionMode(offsetConversionMode);
+        serializer.setTypeSystemMode(typeSystemMode);
+        serializer.setTypeRefGeneratorSupplier(FullyQualifiedTypeRefGenerator::new);
+        serializer.setIdRefGeneratorSupplier(SequentialIdRefGenerator::new);
+    }
+
+    @Override
+    public void process(JCas aJCas) throws AnalysisEngineProcessException
+    {
+        try (OutputStream docOS = getOutputStream(aJCas, ".json")) {
+            serializer.serialize(aJCas.getCas(), docOS);
+        }
+        catch (Exception e) {
+            throw new AnalysisEngineProcessException(e);
+        }
+    }
+}

--- a/dkpro-core-io-json-asl/src/test/java/org/dkpro/core/io/json/JsonCasReaderWriterTest.java
+++ b/dkpro-core-io-json-asl/src/test/java/org/dkpro/core/io/json/JsonCasReaderWriterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.core.io.json;
+
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+import static org.apache.uima.fit.pipeline.SimplePipeline.runPipeline;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.dkpro.core.io.conll.Conll2000Reader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class JsonCasReaderWriterTest
+{
+    @Test
+    public void testWriteAndReadBack(@TempDir File tempDir) throws Exception
+    {
+        var reader = createReaderDescription(Conll2000Reader.class, "sourceLocation",
+                "src/test/resources/conll/2000/chunk2000_test.conll");
+
+        var writer = createEngineDescription(JsonCasWriter.class, "targetLocation", tempDir);
+
+        runPipeline(reader, writer);
+
+        var jsonFiles = tempDir.listFiles((dir, name) -> name.endsWith(".json"));
+        assertThat(jsonFiles).isNotNull().isNotEmpty();
+
+        var jsonReader = createReader(JsonCasReader.class, "sourceLocation",
+                tempDir.getAbsolutePath(), "patterns", "*.json");
+
+        var jcas = JCasFactory.createJCas();
+        jsonReader.getNext(jcas.getCas());
+
+        assertThat(jcas.getDocumentText()).isNotNull().isNotEmpty();
+        assertThat(jcas.getCas().getAnnotationIndex()).isNotEmpty();
+    }
+}

--- a/dkpro-core-parent-common/pom.xml
+++ b/dkpro-core-parent-common/pom.xml
@@ -53,6 +53,7 @@
     <!-- The Spring version should be at least whatever uimaFIT requires -->
     <spring.version>7.0.7</spring.version>
     <uima.version>3.6.1</uima.version>
+    <uima-io-json.version>0.5.0</uima-io-json.version>
     <uimafit.plugin.version>${uima.version}</uimafit.plugin.version>
   </properties>
 
@@ -170,6 +171,11 @@
         <version>${uima.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.uima</groupId>
+        <artifactId>uimaj-io-json</artifactId>
+        <version>${uima-io-json.version}</version>
       </dependency>
       <dependency>
         <groupId>org.yaml</groupId>


### PR DESCRIPTION
**What's in the PR**
- Add JsonCasReader and JsonCasWriter for the UIMA JSON CAS format (backed by uimaj-io-json)
- Add round-trip test for the new JsonCasReader/JsonCasWriter pair
- Manage uimaj-io-json version in dkpro-core-parent-common dependencyManagement
- uimaj-io-json (new managed dependency) 0.5.0

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
